### PR TITLE
Add physical/background: gender, height, age, gold

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>AD&amp;D 2e Character Generator</title>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚔</text></svg>" />
+    <link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%20100%20100%27%3E%3Ctext%20y%3D%27.9em%27%20font-size%3D%2790%27%3E%E2%9A%94%3C%2Ftext%3E%3C%2Fsvg%3E" />
     <link rel="stylesheet" href="styles.css" />
     <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js"></script>
     <script type="module" src="dist/main.js"></script>
@@ -175,13 +175,13 @@
             <div class="field-row">
               <label class="field-label" for="race">Race</label>
               <select id="race" onchange="setRace(this)">
-                <option></option>
-                <option>human</option>
-                <option>dwarf</option>
-                <option>elf</option>
-                <option>gnome</option>
-                <option>halfling</option>
-                <option>half elf</option>
+                <option value=""></option>
+                <option value="human">human</option>
+                <option value="dwarf">dwarf</option>
+                <option value="elf">elf</option>
+                <option value="gnome">gnome</option>
+                <option value="halfling">halfling</option>
+                <option value="halfElf">half elf</option>
               </select>
             </div>
             <div class="field-row">

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>AD&amp;D 2e Character Generator</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚔</text></svg>" />
     <link rel="stylesheet" href="styles.css" />
     <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js"></script>
     <script type="module" src="dist/main.js"></script>

--- a/index.html
+++ b/index.html
@@ -164,6 +164,14 @@
           <h2 class="card-title">Character</h2>
           <div class="char-fields">
             <div class="field-row">
+              <label class="field-label" for="gender">Gender</label>
+              <select id="gender" onchange="setGender(this)">
+                <option value=""></option>
+                <option value="male">male</option>
+                <option value="female">female</option>
+              </select>
+            </div>
+            <div class="field-row">
               <label class="field-label" for="race">Race</label>
               <select id="race" onchange="setRace(this)">
                 <option></option>
@@ -298,6 +306,16 @@
             <dt>Petrification / Polymorph</dt><dd id="poly"></dd>
             <dt>Breath Weapon</dt><dd id="breath"></dd>
             <dt>Spell</dt><dd id="spell"></dd>
+          </dl>
+        </div>
+
+        <div class="stat-card">
+          <h3 class="stat-card-title">Physical &amp; Background</h3>
+          <dl class="stat-dl">
+            <dt>Height</dt><dd id="charHeight"></dd>
+            <dt>Weight</dt><dd id="charWeight"></dd>
+            <dt>Age</dt><dd id="charAge"></dd>
+            <dt>Starting Gold</dt><dd id="charGold"></dd>
           </dl>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <div id="spinner"><div class="loadingspinner"></div></div>
 
     <header class="site-header">
-      <h1>AD&amp;D 2<sup>nd</sup> Edition &mdash; <span>Character Generator</span></h1>
+      <h1>AD&amp;D 2<sup>nd</sup> Edition - <span>Character Generator</span></h1>
     </header>
 
     <main class="layout">
@@ -27,7 +27,7 @@
           <div class="radio-group">
             <label class="radio-option">
               <input type="radio" id="fourd6" name="rolltype" value="4*D6" checked onchange="rollerType()">
-              <span>4d6 &mdash; drop lowest</span>
+              <span>4d6 - drop lowest</span>
             </label>
             <label class="radio-option">
               <input type="radio" id="threed6" name="rolltype" value="3*D6" onchange="rollerType()">

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,4 +1,4 @@
-import { Classes, Races, RaceClassLimits, THAC0S, ISavingThrows, HeightWeightTable, AgeTable, StartingMoneyTable } from './types.js';
+﻿import { Classes, Races, RaceClassLimits, THAC0S, ISavingThrows, HeightWeightTable, AgeTable, StartingMoneyTable } from './types.js';
 
 export const raceClassLimits: RaceClassLimits = {
   human: [Classes.fighter, Classes.thief, Classes.cleric, Classes.mage, Classes.bard, Classes.paladin, Classes.ranger, Classes.druid, Classes.illusionist],
@@ -47,7 +47,7 @@ export const savingThrows: ISavingThrows = {
   }
 };
 
-// PHB Table 1B — Height and Weight by Race and Gender
+// PHB Table 1B - Height and Weight by Race and Gender
 // Heights in inches, weights in lbs. Roll: base + XdY.
 export const heightWeightTable: HeightWeightTable = {
   human: {
@@ -76,7 +76,7 @@ export const heightWeightTable: HeightWeightTable = {
   },
 };
 
-// PHB Table 1A — Starting Age by Race and Class
+// PHB Table 1A - Starting Age by Race and Class
 // Starting age = base + rollXdY(dice, sides)
 export const startingAgeTable: AgeTable = {
   human: {
@@ -126,8 +126,8 @@ export const startingAgeTable: AgeTable = {
   },
 };
 
-// PHB Table 23 — Starting Money by Class
-// Starting gold = rollXdY(dice, sides) × multiplier
+// PHB Table 23 - Starting Money by Class
+// Starting gold = rollXdY(dice, sides) �- multiplier
 export const startingMoneyTable: StartingMoneyTable = {
   fighter:     { dice: 5, sides: 4, multiplier: 10 },
   paladin:     { dice: 5, sides: 4, multiplier: 10 },

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,4 +1,4 @@
-﻿import { Classes, Races, RaceClassLimits, THAC0S, ISavingThrows, HeightWeightTable, AgeTable, StartingMoneyTable } from './types.js';
+import { Classes, Races, RaceClassLimits, THAC0S, ISavingThrows, HeightWeightTable, AgeTable, StartingMoneyTable } from './types.js';
 
 export const raceClassLimits: RaceClassLimits = {
   human: [Classes.fighter, Classes.thief, Classes.cleric, Classes.mage, Classes.bard, Classes.paladin, Classes.ranger, Classes.druid, Classes.illusionist],
@@ -127,7 +127,7 @@ export const startingAgeTable: AgeTable = {
 };
 
 // PHB Table 23 - Starting Money by Class
-// Starting gold = rollXdY(dice, sides) �- multiplier
+// Starting gold = rollXdY(dice, sides) * multiplier
 export const startingMoneyTable: StartingMoneyTable = {
   fighter:     { dice: 5, sides: 4, multiplier: 10 },
   paladin:     { dice: 5, sides: 4, multiplier: 10 },

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,4 +1,4 @@
-import { Classes, Races, RaceClassLimits, THAC0S, ISavingThrows } from './types.js';
+import { Classes, Races, RaceClassLimits, THAC0S, ISavingThrows, HeightWeightTable, AgeTable, StartingMoneyTable } from './types.js';
 
 export const raceClassLimits: RaceClassLimits = {
   human: [Classes.fighter, Classes.thief, Classes.cleric, Classes.mage, Classes.bard, Classes.paladin, Classes.ranger, Classes.druid, Classes.illusionist],
@@ -45,4 +45,97 @@ export const savingThrows: ISavingThrows = {
     breath: [15, 15, 15, 15, 15, 13, 13, 13, 13, 13, 11, 11, 11, 11, 11, 9, 9, 9, 9, 9],
     spell: [12, 12, 12, 12, 12, 10, 10, 10, 10, 10, 8, 8, 8, 8, 8, 6, 6, 6, 6, 6]
   }
+};
+
+// PHB Table 1B — Height and Weight by Race and Gender
+// Heights in inches, weights in lbs. Roll: base + XdY.
+export const heightWeightTable: HeightWeightTable = {
+  human: {
+    male:   { htBase: 60, htDice: 2, htSides: 10, wtBase: 140, wtDice: 6, wtSides: 10 },
+    female: { htBase: 59, htDice: 2, htSides: 10, wtBase: 100, wtDice: 4, wtSides: 10 },
+  },
+  dwarf: {
+    male:   { htBase: 43, htDice: 1, htSides: 10, wtBase: 130, wtDice: 4, wtSides: 10 },
+    female: { htBase: 41, htDice: 1, htSides: 10, wtBase: 105, wtDice: 3, wtSides: 10 },
+  },
+  elf: {
+    male:   { htBase: 55, htDice: 1, htSides: 10, wtBase: 90,  wtDice: 3, wtSides: 10 },
+    female: { htBase: 50, htDice: 1, htSides: 10, wtBase: 70,  wtDice: 3, wtSides: 10 },
+  },
+  gnome: {
+    male:   { htBase: 38, htDice: 1, htSides: 6,  wtBase: 72,  wtDice: 5, wtSides: 4  },
+    female: { htBase: 36, htDice: 1, htSides: 6,  wtBase: 68,  wtDice: 5, wtSides: 4  },
+  },
+  halfling: {
+    male:   { htBase: 32, htDice: 2, htSides: 8,  wtBase: 52,  wtDice: 5, wtSides: 4  },
+    female: { htBase: 30, htDice: 2, htSides: 8,  wtBase: 48,  wtDice: 5, wtSides: 4  },
+  },
+  halfElf: {
+    male:   { htBase: 60, htDice: 2, htSides: 6,  wtBase: 110, wtDice: 3, wtSides: 12 },
+    female: { htBase: 58, htDice: 2, htSides: 6,  wtBase: 85,  wtDice: 3, wtSides: 12 },
+  },
+};
+
+// PHB Table 1A — Starting Age by Race and Class
+// Starting age = base + rollXdY(dice, sides)
+export const startingAgeTable: AgeTable = {
+  human: {
+    fighter:     { base: 15, dice: 1, sides: 4 },
+    paladin:     { base: 17, dice: 1, sides: 4 },
+    ranger:      { base: 15, dice: 1, sides: 4 },
+    cleric:      { base: 15, dice: 1, sides: 6 },
+    druid:       { base: 15, dice: 1, sides: 6 },
+    mage:        { base: 15, dice: 2, sides: 8 },
+    illusionist: { base: 15, dice: 2, sides: 8 },
+    thief:       { base: 15, dice: 1, sides: 4 },
+    bard:        { base: 15, dice: 1, sides: 4 },
+  },
+  dwarf: {
+    fighter: { base: 40, dice: 5, sides: 4 },
+    cleric:  { base: 40, dice: 5, sides: 4 },
+    thief:   { base: 40, dice: 3, sides: 6 },
+  },
+  elf: {
+    fighter:  { base: 100, dice: 5, sides: 6 },
+    ranger:   { base: 105, dice: 5, sides: 6 },
+    cleric:   { base: 105, dice: 5, sides: 6 },
+    mage:     { base: 110, dice: 5, sides: 6 },
+    thief:    { base: 100, dice: 5, sides: 6 },
+    bard:     { base: 100, dice: 5, sides: 6 },
+  },
+  gnome: {
+    fighter:     { base: 60, dice: 6, sides: 4 },
+    cleric:      { base: 60, dice: 7, sides: 4 },
+    illusionist: { base: 60, dice: 9, sides: 4 },
+    thief:       { base: 60, dice: 5, sides: 4 },
+  },
+  halfling: {
+    fighter: { base: 20, dice: 2, sides: 4 },
+    cleric:  { base: 22, dice: 2, sides: 4 },
+    thief:   { base: 20, dice: 1, sides: 4 },
+  },
+  halfElf: {
+    fighter:  { base: 15, dice: 2, sides: 4 },
+    paladin:  { base: 17, dice: 2, sides: 4 },
+    ranger:   { base: 15, dice: 2, sides: 4 },
+    cleric:   { base: 17, dice: 2, sides: 4 },
+    druid:    { base: 17, dice: 2, sides: 4 },
+    mage:     { base: 18, dice: 3, sides: 4 },
+    thief:    { base: 15, dice: 2, sides: 4 },
+    bard:     { base: 15, dice: 2, sides: 4 },
+  },
+};
+
+// PHB Table 23 — Starting Money by Class
+// Starting gold = rollXdY(dice, sides) × multiplier
+export const startingMoneyTable: StartingMoneyTable = {
+  fighter:     { dice: 5, sides: 4, multiplier: 10 },
+  paladin:     { dice: 5, sides: 4, multiplier: 10 },
+  ranger:      { dice: 5, sides: 4, multiplier: 10 },
+  cleric:      { dice: 3, sides: 6, multiplier: 10 },
+  druid:       { dice: 3, sides: 6, multiplier: 10 },
+  mage:        { dice: 2, sides: 4, multiplier: 10 },
+  illusionist: { dice: 2, sides: 4, multiplier: 10 },
+  thief:       { dice: 2, sides: 6, multiplier: 10 },
+  bard:        { dice: 2, sides: 6, multiplier: 10 },
 };

--- a/src/dice.ts
+++ b/src/dice.ts
@@ -20,3 +20,10 @@ export function roll4d6DropLowest(): number {
   const lowest = Math.min(...r);
   return r.reduce((a, b) => a + b, 0) - lowest;
 }
+
+/** Roll xDy: sum of x rolls of a y-sided die */
+export function rollXdY(x: number, y: number): number {
+  let total = 0;
+  for (let i = 0; i < x; i++) total += rollDie(y);
+  return total;
+}

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -44,6 +44,10 @@ export interface CharacterData {
   poly: string;
   breath: string;
   spell: string;
+  height: string;
+  weight: string;
+  age: string;
+  startingGold: string;
 }
 
 /** Convert a string to a number if possible, otherwise keep as string */
@@ -64,9 +68,9 @@ export function buildSheetData(d: CharacterData): (string | number)[][] {
     // Row 2  — data
     [E, d.className, cv(d.level), E, E, E, E, E, E, E, E, E, E, E, E],
     // Row 3  — labels: biography
-    ['Alignment', 'Weight', 'Height', 'Social Class', 'Eyes', 'Family/clan', E, E, E, E, E, E, E, E, E],
-    // Row 4  — data (manual fill)
-    [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
+    ['Alignment', 'Weight', 'Height', 'Age', 'Eyes', 'Family/clan', E, E, E, E, E, E, E, E, E],
+    // Row 4  — data
+    [E, cv(d.weight), d.height, cv(d.age), E, E, E, E, E, E, E, E, E, E, E],
     // Row 5  — empty
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
     // Row 6  — section headers
@@ -124,7 +128,7 @@ export function buildSheetData(d: CharacterData): (string | number)[][] {
     ['Experience Points', E, E, 'Money', E, 'Valuables', E, E, E, 'Magic items', E, E, E, E, E],
     [E, E, E, 'PP', E, E, E, E, E, E, E, E, E, E, E],
     [E, E, E, 'EP', E, E, E, E, E, E, E, E, E, E, E],
-    [E, E, E, 'GP', E, E, E, E, E, E, E, E, E, E, E],
+    [E, E, E, 'GP', cv(d.startingGold), E, E, E, E, E, E, E, E, E, E],
     [E, E, E, 'SP', E, E, E, E, E, E, E, E, E, E, E],
     [E, E, E, 'CP', E, E, E, E, E, E, E, E, E, E, E],
     // Row 41 — Spells/day header

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -1,4 +1,4 @@
-// SheetJS is loaded via CDN script tag in index.html
+﻿// SheetJS is loaded via CDN script tag in index.html
 declare const XLSX: any;
 
 export interface CharacterData {
@@ -63,77 +63,77 @@ export function buildSheetData(d: CharacterData): (string | number)[][] {
   // Columns A–O (indices 0–14). Data values are placed in the row below their label row.
   // Saving throw values go in col M (index 12) on the same row as their col-L label.
   const aoa: (string | number)[][] = [
-    // Row 1  — labels: Name / Class / Level / ...
+    // Row 1  - labels: Name / Class / Level / ...
     ['Name', 'Class', 'Level', 'Appearance', 'Religion', 'Hair', E, E, E, E, E, E, E, E, E],
-    // Row 2  — data
+    // Row 2  - data
     [E, d.className, cv(d.level), E, E, E, E, E, E, E, E, E, E, E, E],
-    // Row 3  — labels: biography
+    // Row 3  - labels: biography
     ['Alignment', 'Weight', 'Height', 'Age', 'Eyes', 'Family/clan', E, E, E, E, E, E, E, E, E],
-    // Row 4  — data
+    // Row 4  - data
     [E, cv(d.weight), d.height, cv(d.age), E, E, E, E, E, E, E, E, E, E, E],
-    // Row 5  — empty
+    // Row 5  - empty
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
-    // Row 6  — section headers
+    // Row 6  - section headers
     ['Abilities', E, E, E, E, E, E, 'Movement', E, E, E, 'Saving throws', E, E, E],
-    // Row 7  — Strength labels | Movement: Base | Save label: Paralyze/Poison | Save value
+    // Row 7  - Strength labels | Movement: Base | Save label: Paralyze/Poison | Save value
     ['Strength', 'hit prob', 'dmg adjust', 'wgt allow', 'max press', 'opn door', 'BB/LG', 'Base', E, E, E, 'Paralyze/Poison', cv(d.para), E, E],
-    // Row 8  — Strength data | Movement: Light sub-label | Save label: Rod/Staff/Wand | Save value
+    // Row 8  - Strength data | Movement: Light sub-label | Save label: Rod/Staff/Wand | Save value
     [cv(d.str), cv(d.hitProb), cv(d.dmgAdj), cv(d.wgtAllow), cv(d.maxPress), cv(d.opnDoor), cv(d.bbLg), 'Light', E, E, E, 'Rod/Staff/Wand', cv(d.rod), E, E],
-    // Row 9  — Dexterity labels | Movement: Mod | Save label: Petrify/Polymorph | Save value
+    // Row 9  - Dexterity labels | Movement: Mod | Save label: Petrify/Polymorph | Save value
     ['Dexterity', 'rctn adj', 'missile adj', 'def adj', E, E, E, 'Mod', E, E, E, 'Petrify/Polymorph', cv(d.poly), E, E],
-    // Row 10 — Dexterity data | Movement: Heavy | Save label: Breath weapon | Save value
+    // Row 10 - Dexterity data | Movement: Heavy | Save label: Breath weapon | Save value
     [cv(d.dex), cv(d.rctnAdj), cv(d.missileAdj), cv(d.defAdj), E, E, E, 'Heavy', E, E, E, 'Breath weapon', cv(d.breath), E, E],
-    // Row 11 — Constitution labels | Movement: Svr | Save label: Spells | Save value
+    // Row 11 - Constitution labels | Movement: Svr | Save label: Spells | Save value
     ['Constitution', 'HP adj', 'sys shk', 'res surv', 'poison sv', 'regen', E, 'Svr', E, E, E, 'Spells', cv(d.spell), E, E],
-    // Row 12 — Constitution data | Movement: Jog x2
+    // Row 12 - Constitution data | Movement: Jog x2
     [cv(d.con), cv(d.hpAdj), cv(d.sysShk), cv(d.resSurv), cv(d.poisonSv), cv(d.regen), E, 'Jog', 'x2', E, E, E, E, E, E],
-    // Row 13 — Intelligence labels | Movement: Run x3
+    // Row 13 - Intelligence labels | Movement: Run x3
     ['Intelligence', 'no. lang', 'spl lvl', 'lrn spl', 'spl/lvl', 'spl immune', E, 'Run', 'x3', E, E, E, E, E, E],
-    // Row 14 — Intelligence data | Movement: Run x4
+    // Row 14 - Intelligence data | Movement: Run x4
     [cv(d.int), cv(d.noLang), cv(d.splLvl), cv(d.lrnSpl), cv(d.splPerLvl), cv(d.splImun), E, 'Run', 'x4', E, E, E, E, E, E],
-    // Row 15 — Wisdom labels | Movement: Run x5
+    // Row 15 - Wisdom labels | Movement: Run x5
     ['Wisdom', 'mgc def adj', 'bonus spls', 'spl fail', 'spl immune', E, E, 'Run', 'x5', E, E, E, E, E, E],
-    // Row 16 — Wisdom data
+    // Row 16 - Wisdom data
     [cv(d.wis), cv(d.mgcDefAdj), cv(d.bonusSp), cv(d.chnFail), cv(d.splImmune), E, E, E, E, E, E, E, E, E, E],
-    // Row 17 — Charisma labels
+    // Row 17 - Charisma labels
     ['Charisma', 'mx hench', 'loyal bse', 'rctn adj', E, E, E, E, E, E, E, E, E, E, E],
-    // Row 18 — Charisma data
+    // Row 18 - Charisma data
     [cv(d.chr), cv(d.mxHench), cv(d.loyalBs), cv(d.reactAdj), E, E, E, E, E, E, E, E, E, E, E],
-    // Row 19 — empty
+    // Row 19 - empty
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
-    // Row 20 — section headers: Armour / Hit points / Weapon chart
+    // Row 20 - section headers: Armour / Hit points / Weapon chart
     ['Armour', E, E, 'Hit points', E, 'Weapon chart', E, E, E, E, E, E, E, E, E],
-    // Row 21 — column headers
+    // Row 21 - column headers
     ['AC', E, 'Armour type', E, 'Wounds', 'Weapon', 'No. att/rnd', 'Att adj/dmg adj', 'Thac0', 'Dmg sm/l', 'Range', 'Weight', 'Size', 'Type', 'Speed'],
-    // Row 22 — first AC entry / HP (col E) / THAC0 (col I)
+    // Row 22 - first AC entry / HP (col E) / THAC0 (col I)
     ['Surprised', E, E, E, cv(d.hp), E, E, E, cv(d.thac0), E, E, E, E, E, E],
     // Row 23
     ['Shieldless', E, E, E, E, E, E, E, E, E, E, E, E, E, E],
     // Row 24
     ['Rear', E, E, E, E, E, E, E, E, E, E, E, E, E, E],
-    // Row 25 — empty
+    // Row 25 - empty
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
-    // Row 26 — Special attacks / Proficiencies / Equipment headers
+    // Row 26 - Special attacks / Proficiencies / Equipment headers
     ['Special attacks', E, E, E, E, 'Proficiencies/skills/languages', E, E, E, 'Equipment', E, E, E, E, E],
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
-    // Row 30 — Special Abilities
+    // Row 30 - Special Abilities
     ['Special Abilities', E, E, E, E, E, E, E, E, E, E, E, E, E, E],
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
-    // Row 35 — XP / Money / Valuables / Magic items headers
+    // Row 35 - XP / Money / Valuables / Magic items headers
     ['Experience Points', E, E, 'Money', E, 'Valuables', E, E, E, 'Magic items', E, E, E, E, E],
     [E, E, E, 'PP', E, E, E, E, E, E, E, E, E, E, E],
     [E, E, E, 'EP', E, E, E, E, E, E, E, E, E, E, E],
     [E, E, E, 'GP', cv(d.startingGold), E, E, E, E, E, E, E, E, E, E],
     [E, E, E, 'SP', E, E, E, E, E, E, E, E, E, E, E],
     [E, E, E, 'CP', E, E, E, E, E, E, E, E, E, E, E],
-    // Row 41 — Spells/day header
+    // Row 41 - Spells/day header
     ['Spells/day', E, 'Spell list', E, E, E, E, E, E, E, E, 'Notes', E, E, E],
-    // Rows 42–50 — spell levels 1–9
+    // Rows 42–50 - spell levels 1–9
     [1, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
     [2, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
     [3, E, E, E, E, E, E, E, E, E, E, E, E, E, E],

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -1,4 +1,4 @@
-﻿// SheetJS is loaded via CDN script tag in index.html
+// SheetJS is loaded via CDN script tag in index.html
 declare const XLSX: any;
 
 export interface CharacterData {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -678,15 +678,7 @@ export class Generator {
 
   // Returns the race key used in data tables (e.g. 'halfElf'), or '' if none selected
   private getCurrentRaceKey = (): string => {
-    switch ((this.selectRace as HTMLSelectElement).selectedIndex) {
-      case 1: return 'human';
-      case 2: return 'dwarf';
-      case 3: return 'elf';
-      case 4: return 'gnome';
-      case 5: return 'halfling';
-      case 6: return 'halfElf';
-      default: return '';
-    }
+    return (this.selectRace as HTMLSelectElement).value || '';
   };
 
   // Clear height/weight state and UI labels

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,7 +1,7 @@
-import { Classes, Races, THAC0S } from './types.js';
-import { raceClassLimits, thac0s, savingThrows } from './data.js';
+import { Classes, Races, THAC0S, Gender } from './types.js';
+import { raceClassLimits, thac0s, savingThrows, heightWeightTable, startingAgeTable, startingMoneyTable } from './data.js';
 import { comboToLabel, getEligibleMulticlassCombos, AbilityScores } from './multiclass.js';
-import { rollDie, roll3d6, roll4d6DropLowest } from './dice.js';
+import { rollDie, roll3d6, roll4d6DropLowest, rollXdY } from './dice.js';
 import { exportCharacterSheet } from './exporter.js';
 
 export class Generator {
@@ -24,6 +24,13 @@ export class Generator {
   bndBrs = 0;
   hitProb = 0;
   DmgAdj = 0;
+
+  // Physical & background
+  gender: Gender | '' = '';
+  height = '';
+  weight = 0;
+  age = 0;
+  startingGold = 0;
 
   // Attributes
   strInit = 0;
@@ -93,10 +100,15 @@ export class Generator {
   labelSvPoly: any;
   labelSvSpell: any;
   labelSvBreath: any;
+  labelHeight: any;
+  labelWeight: any;
+  labelAge: any;
+  labelGold: any;
   selectClass: any;
   selectMulticlass: any;
   selectRace: any;
   selectLevel: any;
+  selectGender: any;
   rollType: any;
   spinner: any;
 
@@ -167,6 +179,12 @@ export class Generator {
     this.selectClass = document.getElementById('class') as HTMLSelectElement;
   this.selectMulticlass = document.getElementById('multiclass') as HTMLSelectElement | null;
     this.selectLevel = document.getElementById('lvl') as HTMLSelectElement;
+    this.selectGender = document.getElementById('gender') as HTMLSelectElement;
+
+    this.labelHeight = document.getElementById('charHeight') as HTMLElement;
+    this.labelWeight = document.getElementById('charWeight') as HTMLElement;
+    this.labelAge    = document.getElementById('charAge')    as HTMLElement;
+    this.labelGold   = document.getElementById('charGold')   as HTMLElement;
 
     this.rollType = document.getElementsByName('rolltype') as any;
     this.spinner = document.getElementById('spinner') as HTMLElement;
@@ -315,6 +333,16 @@ export class Generator {
     }
     this.selectLevel.selectedIndex = 0;
     this.selectRace.selectedIndex = 0;
+    if (this.selectGender) this.selectGender.selectedIndex = 0;
+    this.gender = '';
+    this.height = '';
+    this.weight = 0;
+    this.age = 0;
+    this.startingGold = 0;
+    if (this.labelHeight) this.labelHeight.textContent = '';
+    if (this.labelWeight) this.labelWeight.textContent = '';
+    if (this.labelAge)    this.labelAge.textContent    = '';
+    if (this.labelGold)   this.labelGold.textContent   = '';
     this.refreshMulticlassOptions();
   };
 
@@ -648,6 +676,74 @@ export class Generator {
     return 'mage';
   };
 
+  // Returns the race key used in data tables (e.g. 'halfElf'), or '' if none selected
+  private getCurrentRaceKey = (): string => {
+    switch ((this.selectRace as HTMLSelectElement).selectedIndex) {
+      case 1: return 'human';
+      case 2: return 'dwarf';
+      case 3: return 'elf';
+      case 4: return 'gnome';
+      case 5: return 'halfling';
+      case 6: return 'halfElf';
+      default: return '';
+    }
+  };
+
+  // Roll and display height and weight based on current race + gender
+  calcPhysical = () => {
+    const raceKey = this.getCurrentRaceKey();
+    if (!raceKey || !this.gender) return;
+    const entry = heightWeightTable[raceKey]?.[this.gender];
+    if (!entry) return;
+    const totalInches = entry.htBase + rollXdY(entry.htDice, entry.htSides);
+    this.height = `${Math.floor(totalInches / 12)}'${totalInches % 12}"`;
+    this.weight = entry.wtBase + rollXdY(entry.wtDice, entry.wtSides);
+    if (this.labelHeight) this.labelHeight.textContent = this.height;
+    if (this.labelWeight) this.labelWeight.textContent = `${this.weight} lbs`;
+  };
+
+  // Set gender and re-roll physical stats
+  setGender = (ddl: HTMLSelectElement) => {
+    this.gender = ddl.value as Gender | '';
+    this.calcPhysical();
+  };
+
+  // Roll starting age from race + class tables; for multiclass takes the oldest result
+  calcAge = () => {
+    const raceKey = this.getCurrentRaceKey();
+    if (!raceKey) return;
+    const classes = this.getSelectedClasses();
+    if (!classes.length) return;
+    const raceAges = startingAgeTable[raceKey];
+    if (!raceAges) return;
+    let maxAge = 0;
+    for (const cls of classes) {
+      const entry = raceAges[cls];
+      if (!entry) continue;
+      const rolled = entry.base + rollXdY(entry.dice, entry.sides);
+      if (rolled > maxAge) maxAge = rolled;
+    }
+    if (!maxAge) return;
+    this.age = maxAge;
+    if (this.labelAge) this.labelAge.textContent = this.age.toString();
+  };
+
+  // Roll starting gold from class tables; for multiclass takes the highest result
+  calcMoney = () => {
+    const classes = this.getSelectedClasses();
+    if (!classes.length) return;
+    let maxGold = 0;
+    for (const cls of classes) {
+      const entry = startingMoneyTable[cls];
+      if (!entry) continue;
+      const rolled = rollXdY(entry.dice, entry.sides) * entry.multiplier;
+      if (rolled > maxGold) maxGold = rolled;
+    }
+    if (!maxGold) return;
+    this.startingGold = maxGold;
+    if (this.labelGold) this.labelGold.textContent = `${maxGold} gp`;
+  };
+
   // Set the class (single or multiclass)
   setClass = (ddl: HTMLSelectElement) => {
     const selected = this.getSelectedClasses();
@@ -674,6 +770,8 @@ export class Generator {
     if (selected.length) {
       const hds = selected.map(hdFor) as number[];
       this.hitdice = Math.max(...hds);
+      this.calcAge();
+      this.calcMoney();
       return;
     }
 
@@ -701,6 +799,8 @@ export class Generator {
       default:
         throw new Error('Unknown class type');
     }
+    this.calcAge();
+    this.calcMoney();
   };
 
   zeroMOds = () => {
@@ -808,8 +908,10 @@ export class Generator {
       default: throw Error('Unknown race');
     }
     this.applyRacialMods();
-  // Race changed; refresh multiclass options
+  // Race changed; refresh multiclass options and re-roll physical/age
   this.refreshMulticlassOptions();
+  this.calcPhysical();
+  this.calcAge();
   };
 
   // Calculate hp and thac0
@@ -898,6 +1000,10 @@ export class Generator {
       poly:      this.labelSvPoly?.textContent    || '',
       breath:    this.labelSvBreath?.textContent  || '',
       spell:     this.labelSvSpell?.textContent   || '',
+      height:      this.height || '',
+      weight:      this.weight ? this.weight.toString() : '',
+      age:         this.age    ? this.age.toString()    : '',
+      startingGold:this.startingGold ? this.startingGold.toString() : '',
     };
   };
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -689,12 +689,20 @@ export class Generator {
     }
   };
 
+  // Clear height/weight state and UI labels
+  private clearPhysical = () => {
+    this.height = '';
+    this.weight = 0;
+    if (this.labelHeight) this.labelHeight.textContent = '';
+    if (this.labelWeight) this.labelWeight.textContent = '';
+  };
+
   // Roll and display height and weight based on current race + gender
   calcPhysical = () => {
     const raceKey = this.getCurrentRaceKey();
-    if (!raceKey || !this.gender) return;
+    if (!raceKey || !this.gender) { this.clearPhysical(); return; }
     const entry = heightWeightTable[raceKey]?.[this.gender];
-    if (!entry) return;
+    if (!entry) { this.clearPhysical(); return; }
     const totalInches = entry.htBase + rollXdY(entry.htDice, entry.htSides);
     this.height = `${Math.floor(totalInches / 12)}'${totalInches % 12}"`;
     this.weight = entry.wtBase + rollXdY(entry.wtDice, entry.wtSides);
@@ -711,11 +719,11 @@ export class Generator {
   // Roll starting age from race + class tables; for multiclass takes the oldest result
   calcAge = () => {
     const raceKey = this.getCurrentRaceKey();
-    if (!raceKey) return;
+    if (!raceKey) { this.age = 0; if (this.labelAge) this.labelAge.textContent = ''; return; }
     const classes = this.getSelectedClasses();
-    if (!classes.length) return;
+    if (!classes.length) { this.age = 0; if (this.labelAge) this.labelAge.textContent = ''; return; }
     const raceAges = startingAgeTable[raceKey];
-    if (!raceAges) return;
+    if (!raceAges) { this.age = 0; if (this.labelAge) this.labelAge.textContent = ''; return; }
     let maxAge = 0;
     for (const cls of classes) {
       const entry = raceAges[cls];
@@ -723,7 +731,7 @@ export class Generator {
       const rolled = entry.base + rollXdY(entry.dice, entry.sides);
       if (rolled > maxAge) maxAge = rolled;
     }
-    if (!maxAge) return;
+    if (!maxAge) { this.age = 0; if (this.labelAge) this.labelAge.textContent = ''; return; }
     this.age = maxAge;
     if (this.labelAge) this.labelAge.textContent = this.age.toString();
   };
@@ -731,7 +739,7 @@ export class Generator {
   // Roll starting gold from class tables; for multiclass takes the highest result
   calcMoney = () => {
     const classes = this.getSelectedClasses();
-    if (!classes.length) return;
+    if (!classes.length) { this.startingGold = 0; if (this.labelGold) this.labelGold.textContent = ''; return; }
     let maxGold = 0;
     for (const cls of classes) {
       const entry = startingMoneyTable[cls];
@@ -739,7 +747,7 @@ export class Generator {
       const rolled = rollXdY(entry.dice, entry.sides) * entry.multiplier;
       if (rolled > maxGold) maxGold = rolled;
     }
-    if (!maxGold) return;
+    if (!maxGold) { this.startingGold = 0; if (this.labelGold) this.labelGold.textContent = ''; return; }
     this.startingGold = maxGold;
     if (this.labelGold) this.labelGold.textContent = `${maxGold} gp`;
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ declare global {
     setRace: (ddl: HTMLSelectElement) => void;
     setClass: (ddl: HTMLSelectElement) => void;
     setLevel: (ddl: HTMLSelectElement) => void;
+    setGender: (ddl: HTMLSelectElement) => void;
     noRollType: () => void;
     rollerType: () => void;
     exportSheet: () => void;
@@ -25,6 +26,7 @@ window.addEventListener('load', () => {
   window.setRace = (ddl) => gen.setRace(ddl);
   window.setClass = (ddl) => gen.setClass(ddl);
   window.setLevel = (ddl) => gen.setLevel(ddl);
+  window.setGender = (ddl) => gen.setGender(ddl);
   window.noRollType = () => gen.dmMode();
   window.rollerType = () => gen.genMode();
   window.exportSheet = () => gen.exportSheet();

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,3 +51,34 @@ export enum Races {
   halfling = 'halfling',
   halfElf = 'halfElf'
 }
+
+export type Gender = 'male' | 'female';
+
+export interface PhysicalEntry {
+  htBase: number;
+  htDice: number;
+  htSides: number;
+  wtBase: number;
+  wtDice: number;
+  wtSides: number;
+}
+
+export interface HeightWeightTable {
+  [race: string]: { male: PhysicalEntry; female: PhysicalEntry };
+}
+
+export interface AgeEntry {
+  base: number;
+  dice: number;
+  sides: number;
+}
+
+export type AgeTable = { [race: string]: { [classKey: string]: AgeEntry } };
+
+export interface MoneyEntry {
+  dice: number;
+  sides: number;
+  multiplier: number;
+}
+
+export type StartingMoneyTable = { [classKey: string]: MoneyEntry };

--- a/tests/data.test.ts
+++ b/tests/data.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 // Import built JS to avoid TS import extension issues
-import { raceClassLimits, thac0s, savingThrows } from '../dist/data.js';
+import { raceClassLimits, thac0s, savingThrows, heightWeightTable, startingAgeTable, startingMoneyTable } from '../dist/data.js';
 import { Classes } from '../dist/types.js';
 
 describe('data tables', () => {
@@ -61,5 +61,102 @@ describe('data tables', () => {
 
   it('mage rod save at level 1 is 11', () => {
     expect(savingThrows.mage.rod[0]).toBe(11);
+  });
+});
+
+const ALL_RACES = ['human', 'dwarf', 'elf', 'gnome', 'halfling', 'halfElf'];
+const ALL_CLASSES = ['fighter', 'paladin', 'ranger', 'cleric', 'druid', 'mage', 'illusionist', 'thief', 'bard'];
+
+describe('heightWeightTable', () => {
+  it('has entries for all six races', () => {
+    for (const race of ALL_RACES) {
+      expect(heightWeightTable, `missing race: ${race}`).toHaveProperty(race);
+    }
+  });
+
+  it('each race has male and female entries', () => {
+    for (const race of ALL_RACES) {
+      expect(heightWeightTable[race]).toHaveProperty('male');
+      expect(heightWeightTable[race]).toHaveProperty('female');
+    }
+  });
+
+  it('each entry has all required numeric fields', () => {
+    for (const race of ALL_RACES) {
+      for (const gender of ['male', 'female'] as const) {
+        const e = heightWeightTable[race][gender];
+        for (const field of ['htBase', 'htDice', 'htSides', 'wtBase', 'wtDice', 'wtSides']) {
+          expect(typeof e[field as keyof typeof e], `${race}.${gender}.${field}`).toBe('number');
+        }
+      }
+    }
+  });
+
+  it('human male has htBase 60 and female htBase 59', () => {
+    expect(heightWeightTable.human.male.htBase).toBe(60);
+    expect(heightWeightTable.human.female.htBase).toBe(59);
+  });
+
+  it('dwarf is shorter than human (smaller htBase)', () => {
+    expect(heightWeightTable.dwarf.male.htBase).toBeLessThan(heightWeightTable.human.male.htBase);
+  });
+});
+
+describe('startingAgeTable', () => {
+  it('has entries for all six races', () => {
+    for (const race of ALL_RACES) {
+      expect(startingAgeTable, `missing race: ${race}`).toHaveProperty(race);
+    }
+  });
+
+  it('human has entries for all nine classes', () => {
+    for (const cls of ALL_CLASSES) {
+      expect(startingAgeTable.human, `human missing class: ${cls}`).toHaveProperty(cls);
+    }
+  });
+
+  it('each entry has base, dice, and sides as numbers', () => {
+    for (const race of ALL_RACES) {
+      for (const [cls, entry] of Object.entries(startingAgeTable[race])) {
+        expect(typeof entry.base,  `${race}.${cls}.base`).toBe('number');
+        expect(typeof entry.dice,  `${race}.${cls}.dice`).toBe('number');
+        expect(typeof entry.sides, `${race}.${cls}.sides`).toBe('number');
+      }
+    }
+  });
+
+  it('non-human races have plausible base ages (> human base)', () => {
+    expect(startingAgeTable.elf.fighter.base).toBeGreaterThan(startingAgeTable.human.fighter.base);
+    expect(startingAgeTable.dwarf.fighter.base).toBeGreaterThan(startingAgeTable.human.fighter.base);
+  });
+
+  it('dwarf has no paladin entry (class not available to dwarves)', () => {
+    expect(startingAgeTable.dwarf).not.toHaveProperty('paladin');
+  });
+});
+
+describe('startingMoneyTable', () => {
+  it('has entries for all nine classes', () => {
+    for (const cls of ALL_CLASSES) {
+      expect(startingMoneyTable, `missing class: ${cls}`).toHaveProperty(cls);
+    }
+  });
+
+  it('each entry has dice, sides, and multiplier as numbers', () => {
+    for (const [cls, entry] of Object.entries(startingMoneyTable)) {
+      expect(typeof entry.dice,       `${cls}.dice`).toBe('number');
+      expect(typeof entry.sides,      `${cls}.sides`).toBe('number');
+      expect(typeof entry.multiplier, `${cls}.multiplier`).toBe('number');
+    }
+  });
+
+  it('all multipliers are 10 (PHB Table 23)', () => {
+    for (const [cls, entry] of Object.entries(startingMoneyTable)) {
+      expect(entry.multiplier, `${cls}.multiplier`).toBe(10);
+    }
+  });
+
+  it('fighters roll more dice than mages', () => {
+    expect(startingMoneyTable.fighter.dice).toBeGreaterThan(startingMoneyTable.mage.dice);
   });
 });

--- a/tests/dice.test.ts
+++ b/tests/dice.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Import built JS to avoid TS extension resolution issues in tests
-import { rollDie, roll3d6, roll4d6DropLowest } from '../dist/dice.js';
+import { rollDie, roll3d6, roll4d6DropLowest, rollXdY } from '../dist/dice.js';
 
 function setMockRandomSequence(seq: number[]) {
   let i = 0;
@@ -51,5 +51,21 @@ describe('dice', () => {
     // Without rejection the first value would give 4294967293 % 6 + 1 = 2.
     setMockRandomSequence([4294967293, 2]);
     expect(rollDie(6)).toBe(3);
+  });
+
+  it('rollXdY returns 0 when x is 0', () => {
+    // No dice rolled; crypto should never be called.
+    expect(rollXdY(0, 6)).toBe(0);
+  });
+
+  it('rollXdY sums exactly x rolls of y-sided die', () => {
+    // Values 0,1,2 → rollDie(6) = 1,2,3 → sum = 6 for x=3
+    setMockRandomSequence([0, 1, 2]);
+    expect(rollXdY(3, 6)).toBe(6);
+  });
+
+  it('rollXdY with x=1 equals a single rollDie(y)', () => {
+    setMockRandomSequence([4]); // 4 % 8 + 1 = 5
+    expect(rollXdY(1, 8)).toBe(5);
   });
 });

--- a/tests/exporter.test.ts
+++ b/tests/exporter.test.ts
@@ -14,6 +14,7 @@ const baseChar: CharacterData = {
   mxHench: '4', loyalBs: '0', reactAdj: '0',
   hp: '24', thac0: '18',
   para: '13', rod: '15', poly: '14', breath: '16', spell: '15',
+  height: `5'10"`, weight: '165', age: '19', startingGold: '120',
 };
 
 // -- cv() --------------------------------------------------------------------
@@ -179,6 +180,34 @@ describe('buildSheetData()', () => {
     expect(aoa[40][0]).toBe('Spells/day');
     expect(aoa[40][2]).toBe('Spell list');
     expect(aoa[40][11]).toBe('Notes');
+  });
+
+  it('row 2 biography labels include Weight, Height, Age', () => {
+    expect(aoa[2][1]).toBe('Weight');
+    expect(aoa[2][2]).toBe('Height');
+    expect(aoa[2][3]).toBe('Age');
+  });
+
+  it('row 3 biography data contains weight, height, age', () => {
+    expect(aoa[3][1]).toBe(165);      // cv('165') → 165
+    expect(aoa[3][2]).toBe(`5'10"`);  // height string kept as-is
+    expect(aoa[3][3]).toBe(19);       // cv('19') → 19
+  });
+
+  it('row 37 GP data cell contains starting gold', () => {
+    // Row 35 = index 34: 'Experience Points' header
+    // Row 36 = PP, Row 37 = EP, Row 38 = GP (index 37)
+    expect(aoa[37][3]).toBe('GP');
+    expect(aoa[37][4]).toBe(120); // cv('120') → 120
+  });
+
+  it('handles empty physical/background values gracefully', () => {
+    const empty: CharacterData = { ...baseChar, height: '', weight: '', age: '', startingGold: '' };
+    const rows = buildSheetData(empty);
+    expect(rows[3][1]).toBe(''); // weight
+    expect(rows[3][2]).toBe(''); // height
+    expect(rows[3][3]).toBe(''); // age
+    expect(rows[37][4]).toBe(''); // startingGold
   });
 });
 


### PR DESCRIPTION
Add gender and physical/background support across UI, data, types, generator, dice and exporter. UI: gender select and a stat card showing Height, Weight, Age and Starting Gold. Types: new Gender, PhysicalEntry, AgeEntry, MoneyEntry and related table types. Data: height/weight, starting age and starting money tables (PHB-based). Dice: add rollXdY helper. Generator: track gender/height/weight/age/startingGold, compute physical attributes, age (oldest for multiclass) and starting gold (highest for multiclass), hook up UI elements and recalc on race/class/gender changes. Exporter: include height, weight, age and startingGold in exported sheet. Main: expose setGender on window. Small UI/reset and display adjustments included.