### PR TITLE
Add alignment, profs, skills and spell support

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,6 +214,21 @@
                 <option>16</option><option>17</option><option>18</option><option>19</option><option>20</option>
               </select>
             </div>
+            <div class="field-row">
+              <label class="field-label" for="alignment">Alignment</label>
+              <select id="alignment" onchange="setAlignment(this)">
+                <option value=""></option>
+                <option value="LG">Lawful Good</option>
+                <option value="LN">Lawful Neutral</option>
+                <option value="LE">Lawful Evil</option>
+                <option value="NG">Neutral Good</option>
+                <option value="TN">True Neutral</option>
+                <option value="NE">Neutral Evil</option>
+                <option value="CG">Chaotic Good</option>
+                <option value="CN">Chaotic Neutral</option>
+                <option value="CE">Chaotic Evil</option>
+              </select>
+            </div>
           </div>
           <div class="derived-stats">
             <div class="derived-stat">
@@ -233,6 +248,52 @@
         </div>
 
       </aside>
+
+      <!-- Thief Skills (shown only when Thief class is selected) -->
+      <div class="card" id="thief-skills-card" style="display:none">
+        <h2 class="card-title">Thief Skills</h2>
+        <div class="thief-points-info">
+          <span>Available: <strong id="ts-avail">0</strong></span>
+          <span>Used: <strong id="ts-used">0</strong></span>
+          <span>Remaining: <strong id="ts-remain">0</strong></span>
+        </div>
+        <table class="thief-table">
+          <thead>
+            <tr><th>Skill</th><th>Base%</th><th>+Add</th><th>Total%</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Pick Pockets</td><td id="ts-pp-base">—</td><td><input type="number" id="ts-pp-add" class="thief-add" min="0" value="0" oninput="updateThiefSkills()" /></td><td id="ts-pp-total">—</td></tr>
+            <tr><td>Open Locks</td><td id="ts-ol-base">—</td><td><input type="number" id="ts-ol-add" class="thief-add" min="0" value="0" oninput="updateThiefSkills()" /></td><td id="ts-ol-total">—</td></tr>
+            <tr><td>Find/Remove Traps</td><td id="ts-frt-base">—</td><td><input type="number" id="ts-frt-add" class="thief-add" min="0" value="0" oninput="updateThiefSkills()" /></td><td id="ts-frt-total">—</td></tr>
+            <tr><td>Move Silently</td><td id="ts-ms-base">—</td><td><input type="number" id="ts-ms-add" class="thief-add" min="0" value="0" oninput="updateThiefSkills()" /></td><td id="ts-ms-total">—</td></tr>
+            <tr><td>Hide in Shadows</td><td id="ts-his-base">—</td><td><input type="number" id="ts-his-add" class="thief-add" min="0" value="0" oninput="updateThiefSkills()" /></td><td id="ts-his-total">—</td></tr>
+            <tr><td>Detect Noise</td><td id="ts-dn-base">—</td><td><input type="number" id="ts-dn-add" class="thief-add" min="0" value="0" oninput="updateThiefSkills()" /></td><td id="ts-dn-total">—</td></tr>
+            <tr><td>Climb Walls</td><td id="ts-cw-base">—</td><td><input type="number" id="ts-cw-add" class="thief-add" min="0" value="0" oninput="updateThiefSkills()" /></td><td id="ts-cw-total">—</td></tr>
+            <tr><td>Read Languages</td><td id="ts-rl-base">—</td><td><input type="number" id="ts-rl-add" class="thief-add" min="0" value="0" oninput="updateThiefSkills()" /></td><td id="ts-rl-total">—</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Bard Skills (shown only when Bard class is selected) -->
+      <div class="card" id="bard-skills-card" style="display:none">
+        <h2 class="card-title">Bard Skills</h2>
+        <div class="thief-points-info">
+          <span>Available: <strong id="bs-avail">0</strong></span>
+          <span>Used: <strong id="bs-used">0</strong></span>
+          <span>Remaining: <strong id="bs-remain">0</strong></span>
+        </div>
+        <table class="thief-table">
+          <thead>
+            <tr><th>Skill</th><th>Base%</th><th>+Add</th><th>Total%</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Pick Pockets</td><td id="bs-pp-base">—</td><td><input type="number" id="bs-pp-add" class="thief-add" min="0" value="0" oninput="updateBardSkills()" /></td><td id="bs-pp-total">—</td></tr>
+            <tr><td>Detect Noise</td><td id="bs-dn-base">—</td><td><input type="number" id="bs-dn-add" class="thief-add" min="0" value="0" oninput="updateBardSkills()" /></td><td id="bs-dn-total">—</td></tr>
+            <tr><td>Climb Walls</td><td id="bs-cw-base">—</td><td><input type="number" id="bs-cw-add" class="thief-add" min="0" value="0" oninput="updateBardSkills()" /></td><td id="bs-cw-total">—</td></tr>
+            <tr><td>Read Languages</td><td id="bs-rl-base">—</td><td><input type="number" id="bs-rl-add" class="thief-add" min="0" value="0" oninput="updateBardSkills()" /></td><td id="bs-rl-total">—</td></tr>
+          </tbody>
+        </table>
+      </div>
 
       <!-- -- RIGHT: STAT PANELS ----------------------- -->
       <div class="stats-area">
@@ -318,6 +379,19 @@
             <dt>Age</dt><dd id="charAge"></dd>
             <dt>Starting Gold</dt><dd id="charGold"></dd>
           </dl>
+        </div>
+
+        <div class="stat-card" id="profs-card" style="display:none">
+          <h3 class="stat-card-title">Proficiency Slots</h3>
+          <dl class="stat-dl">
+            <dt>Weapon Profs</dt><dd id="wpSlots"></dd>
+            <dt>Non-Weapon Profs</dt><dd id="nwpSlots"></dd>
+          </dl>
+        </div>
+
+        <div class="stat-card" id="spells-card" style="display:none">
+          <h3 class="stat-card-title">Spells Per Day</h3>
+          <dl class="stat-dl" id="spells-dl"></dl>
         </div>
 
       </div>

--- a/src/data.ts
+++ b/src/data.ts
@@ -139,3 +139,133 @@ export const startingMoneyTable: StartingMoneyTable = {
   thief:       { dice: 2, sides: 6, multiplier: 10 },
   bard:        { dice: 2, sides: 6, multiplier: 10 },
 };
+
+// Alignment restrictions by class (PHB).
+// Paladin must be LG, Druid must be TN, Ranger must be any Good.
+export const classAlignmentRestrictions: Partial<Record<Classes, string[]>> = {
+  [Classes.paladin]: ['LG'],
+  [Classes.druid]:   ['TN'],
+  [Classes.ranger]:  ['LG', 'NG', 'CG'],
+};
+
+// Proficiency slots per meta-class group.
+// Formula: initial + floor((level - 1) / per)
+export const proficiencySlotData = {
+  warrior: { wp: { initial: 4, per: 3 }, nwp: { initial: 3, per: 3 } },
+  rogue:   { wp: { initial: 2, per: 4 }, nwp: { initial: 3, per: 4 } },
+  priest:  { wp: { initial: 2, per: 4 }, nwp: { initial: 4, per: 3 } },
+  wizard:  { wp: { initial: 1, per: 6 }, nwp: { initial: 4, per: 3 } },
+} as const;
+
+// Spell slots per day indexed as [level-1][spellLevel-1]
+// PHB Table 27 – Wizard Spell Progression (Mage / Illusionist, 9 spell levels)
+const mageSlots: number[][] = [
+  [1,0,0,0,0,0,0,0,0],
+  [2,0,0,0,0,0,0,0,0],
+  [2,1,0,0,0,0,0,0,0],
+  [3,2,0,0,0,0,0,0,0],
+  [4,2,1,0,0,0,0,0,0],
+  [4,2,2,0,0,0,0,0,0],
+  [4,3,2,1,0,0,0,0,0],
+  [4,3,3,2,0,0,0,0,0],
+  [4,3,3,2,1,0,0,0,0],
+  [4,4,3,2,2,0,0,0,0],
+  [4,4,4,3,3,0,0,0,0],
+  [4,4,4,4,4,1,0,0,0],
+  [5,5,5,4,4,2,0,0,0],
+  [5,5,5,4,4,2,1,0,0],
+  [5,5,5,5,5,2,1,0,0],
+  [5,5,5,5,5,3,2,1,0],
+  [5,5,5,5,5,3,3,2,1],
+  [5,5,5,5,5,3,3,2,2],
+  [5,5,5,5,5,3,3,3,3],
+  [5,5,5,5,5,4,3,3,3],
+];
+
+// PHB Priest Spell Progression (Cleric / Druid, 7 spell levels, base without WIS bonus)
+const priestSlots: number[][] = [
+  [1,0,0,0,0,0,0],
+  [2,0,0,0,0,0,0],
+  [2,1,0,0,0,0,0],
+  [3,2,0,0,0,0,0],
+  [3,3,1,0,0,0,0],
+  [3,3,2,0,0,0,0],
+  [3,3,2,1,0,0,0],
+  [3,3,3,2,0,0,0],
+  [4,4,3,2,1,0,0],
+  [4,4,3,3,2,0,0],
+  [5,4,4,3,2,1,0],
+  [6,5,5,3,2,2,0],
+  [6,6,6,4,2,2,0],
+  [6,6,6,5,3,2,1],
+  [6,6,6,6,4,2,1],
+  [7,7,7,6,4,3,1],
+  [7,7,7,7,5,3,2],
+  [8,8,8,8,6,4,2],
+  [9,9,8,8,6,4,2],
+  [9,9,9,8,7,5,2],
+];
+
+// PHB Bard Spell Progression (wizard-type spells, 6 levels; level 1 has no spells)
+const bardSlots: number[][] = [
+  [0,0,0,0,0,0],
+  [1,0,0,0,0,0],
+  [2,0,0,0,0,0],
+  [2,1,0,0,0,0],
+  [3,1,0,0,0,0],
+  [3,2,0,0,0,0],
+  [3,2,1,0,0,0],
+  [3,3,2,0,0,0],
+  [3,3,2,1,0,0],
+  [3,3,3,2,0,0],
+  [3,3,3,2,1,0],
+  [3,3,3,3,2,0],
+  [3,3,3,3,2,1],
+  [3,3,3,3,3,2],
+  [3,3,3,3,3,2],
+  [4,3,3,3,3,2],
+  [4,4,3,3,3,2],
+  [4,4,4,3,3,2],
+  [4,4,4,4,3,3],
+  [4,4,4,4,4,3],
+];
+
+export const spellSlotsPerDay: Partial<Record<Classes, number[][]>> = {
+  [Classes.mage]:        mageSlots,
+  [Classes.illusionist]: mageSlots,
+  [Classes.cleric]:      priestSlots,
+  [Classes.druid]:       priestSlots,
+  [Classes.bard]:        bardSlots,
+};
+
+// Thief base skill scores before racial adjustments or discretionary points (PHB Table 28)
+export const thiefBaseSkills = {
+  pp:  15,  // Pick Pockets
+  ol:  10,  // Open Locks
+  frt:  5,  // Find/Remove Traps
+  ms:  10,  // Move Silently
+  his:  5,  // Hide in Shadows
+  dn:  15,  // Detect Noise
+  cw:  60,  // Climb Walls
+  rl:   0,  // Read Languages
+} as const;
+
+// Racial adjustments added to base thief skill scores (PHB Table 28)
+export const thiefRaceAdjustments: Record<string, {
+  pp: number; ol: number; frt: number; ms: number; his: number; dn: number; cw: number; rl: number;
+}> = {
+  human:    { pp:  0, ol:  0, frt:  0, ms:  0, his:  0, dn:  0, cw:   0, rl:  0 },
+  dwarf:    { pp: -5, ol: 10, frt: 15, ms:  0, his:  0, dn:  0, cw: -10, rl:  0 },
+  elf:      { pp:  5, ol: -5, frt: -5, ms:  5, his: 10, dn: -5, cw:  -5, rl:  0 },
+  gnome:    { pp:  5, ol:  5, frt:  5, ms: 10, his: 10, dn:  0, cw: -15, rl: -5 },
+  halfling: { pp:  5, ol: 10, frt:  0, ms: 15, his: 15, dn:  5, cw: -15, rl: -5 },
+  halfElf:  { pp:  5, ol: -5, frt: -5, ms:  5, his: 10, dn: -5, cw:  -5, rl:  0 },
+};
+
+// Bard base skill scores — bards receive 4 of the thief skills (PHB)
+export const bardBaseSkills = {
+  pp:  15,  // Pick Pockets
+  dn:  15,  // Detect Noise
+  cw:  60,  // Climb Walls
+  rl:   0,  // Read Languages
+} as const;

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,4 +1,4 @@
-import { Classes, Races, RaceClassLimits, THAC0S, ISavingThrows, HeightWeightTable, AgeTable, StartingMoneyTable } from './types.js';
+import { Classes, Races, Alignment, RaceClassLimits, THAC0S, ISavingThrows, HeightWeightTable, AgeTable, StartingMoneyTable } from './types.js';
 
 export const raceClassLimits: RaceClassLimits = {
   human: [Classes.fighter, Classes.thief, Classes.cleric, Classes.mage, Classes.bard, Classes.paladin, Classes.ranger, Classes.druid, Classes.illusionist],
@@ -142,10 +142,10 @@ export const startingMoneyTable: StartingMoneyTable = {
 
 // Alignment restrictions by class (PHB).
 // Paladin must be LG, Druid must be TN, Ranger must be any Good.
-export const classAlignmentRestrictions: Partial<Record<Classes, string[]>> = {
-  [Classes.paladin]: ['LG'],
-  [Classes.druid]:   ['TN'],
-  [Classes.ranger]:  ['LG', 'NG', 'CG'],
+export const classAlignmentRestrictions: Partial<Record<Classes, Alignment[]>> = {
+  [Classes.paladin]: [Alignment.LG],
+  [Classes.druid]:   [Alignment.TN],
+  [Classes.ranger]:  [Alignment.LG, Alignment.NG, Alignment.CG],
 };
 
 // Proficiency slots per meta-class group.

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -48,6 +48,9 @@ export interface CharacterData {
   weight: string;
   age: string;
   startingGold: string;
+  alignment: string;
+  wpSlots: string;
+  nwpSlots: string;
 }
 
 /** Convert a string to a number if possible, otherwise keep as string */
@@ -70,7 +73,7 @@ export function buildSheetData(d: CharacterData): (string | number)[][] {
     // Row 3  - labels: biography
     ['Alignment', 'Weight', 'Height', 'Age', 'Eyes', 'Family/clan', E, E, E, E, E, E, E, E, E],
     // Row 4  - data
-    [E, cv(d.weight), d.height, cv(d.age), E, E, E, E, E, E, E, E, E, E, E],
+    [d.alignment, cv(d.weight), d.height, cv(d.age), E, E, E, E, E, E, E, E, E, E, E],
     // Row 5  - empty
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
     // Row 6  - section headers
@@ -115,7 +118,7 @@ export function buildSheetData(d: CharacterData): (string | number)[][] {
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
     // Row 26 - Special attacks / Proficiencies / Equipment headers
     ['Special attacks', E, E, E, E, 'Proficiencies/skills/languages', E, E, E, 'Equipment', E, E, E, E, E],
-    [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
+    [E, E, E, E, E, d.wpSlots ? `Weapon slots: ${d.wpSlots}` : E, E, d.nwpSlots ? `NWP slots: ${d.nwpSlots}` : E, E, E, E, E, E, E, E],
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
     [E, E, E, E, E, E, E, E, E, E, E, E, E, E, E],
     // Row 30 - Special Abilities

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,5 +1,5 @@
 import { Classes, Races, THAC0S, Gender } from './types.js';
-import { raceClassLimits, thac0s, savingThrows, heightWeightTable, startingAgeTable, startingMoneyTable } from './data.js';
+import { raceClassLimits, thac0s, savingThrows, heightWeightTable, startingAgeTable, startingMoneyTable, classAlignmentRestrictions, proficiencySlotData, spellSlotsPerDay, thiefBaseSkills, thiefRaceAdjustments, bardBaseSkills } from './data.js';
 import { comboToLabel, getEligibleMulticlassCombos, AbilityScores } from './multiclass.js';
 import { rollDie, roll3d6, roll4d6DropLowest, rollXdY } from './dice.js';
 import { exportCharacterSheet } from './exporter.js';
@@ -31,6 +31,8 @@ export class Generator {
   weight = 0;
   age = 0;
   startingGold = 0;
+  baseAge = 0;
+  baseGold = 0;
 
   // Attributes
   strInit = 0;
@@ -112,6 +114,38 @@ export class Generator {
   rollType: any;
   spinner: any;
 
+  // Alignment
+  selectAlignment: any;
+
+  // Proficiency slots
+  profsCard: any;
+  labelWpSlots: any;
+  labelNwpSlots: any;
+
+  // Spell slots
+  spellsCard: any;
+  spellsDl: any;
+
+  // Thief skills
+  thiefSkillsCard: any;
+  tsAvail: any;
+  tsUsed: any;
+  tsRemain: any;
+  thiefSkillBases: HTMLElement[] = [];
+  thiefSkillAdds: HTMLInputElement[] = [];
+  thiefSkillTotals: HTMLElement[] = [];
+  thiefSkillBaseValues: number[] = [0,0,0,0,0,0,0,0];
+
+  // Bard skills
+  bardSkillsCard: any;
+  bsAvail: any;
+  bsUsed: any;
+  bsRemain: any;
+  bardSkillBases: HTMLElement[] = [];
+  bardSkillAdds: HTMLInputElement[] = [];
+  bardSkillTotals: HTMLElement[] = [];
+  bardSkillBaseValues: number[] = [0,0,0,0];
+
   setup = () => {
     this.rollButton.addEventListener('click', this.roll);
     this.getControls();
@@ -188,6 +222,29 @@ export class Generator {
 
     this.rollType = document.getElementsByName('rolltype') as any;
     this.spinner = document.getElementById('spinner') as HTMLElement;
+
+    this.selectAlignment = document.getElementById('alignment') as HTMLSelectElement;
+    this.profsCard = document.getElementById('profs-card');
+    this.labelWpSlots = document.getElementById('wpSlots');
+    this.labelNwpSlots = document.getElementById('nwpSlots');
+    this.spellsCard = document.getElementById('spells-card');
+    this.spellsDl = document.getElementById('spells-dl');
+    this.thiefSkillsCard = document.getElementById('thief-skills-card');
+    this.tsAvail = document.getElementById('ts-avail');
+    this.tsUsed = document.getElementById('ts-used');
+    this.tsRemain = document.getElementById('ts-remain');
+    const skillIds = ['pp','ol','frt','ms','his','dn','cw','rl'];
+    this.thiefSkillBases = skillIds.map(id => document.getElementById(`ts-${id}-base`) as HTMLElement);
+    this.thiefSkillAdds = skillIds.map(id => document.getElementById(`ts-${id}-add`) as HTMLInputElement);
+    this.thiefSkillTotals = skillIds.map(id => document.getElementById(`ts-${id}-total`) as HTMLElement);
+    this.bardSkillsCard = document.getElementById('bard-skills-card');
+    this.bsAvail = document.getElementById('bs-avail');
+    this.bsUsed = document.getElementById('bs-used');
+    this.bsRemain = document.getElementById('bs-remain');
+    const bardSkillIds = ['pp','dn','cw','rl'];
+    this.bardSkillBases = bardSkillIds.map(id => document.getElementById(`bs-${id}-base`) as HTMLElement);
+    this.bardSkillAdds = bardSkillIds.map(id => document.getElementById(`bs-${id}-add`) as HTMLInputElement);
+    this.bardSkillTotals = bardSkillIds.map(id => document.getElementById(`bs-${id}-total`) as HTMLElement);
   };
 
   // Compose current ability scores (after racial mods) from inputs
@@ -232,7 +289,7 @@ export class Generator {
       opt.text = comboToLabel(combo);
       el.appendChild(opt);
     }
-    el.size = Math.min(Math.max(combos.length, 0), 8) || 4;
+    el.size = Math.min(Math.max(combos.length, 2), 8);
     el.style.display = combos.length ? '' : 'none';
   };
 
@@ -339,11 +396,31 @@ export class Generator {
     this.weight = 0;
     this.age = 0;
     this.startingGold = 0;
+    this.baseAge = 0;
+    this.baseGold = 0;
     if (this.labelHeight) this.labelHeight.textContent = '';
     if (this.labelWeight) this.labelWeight.textContent = '';
     if (this.labelAge)    this.labelAge.textContent    = '';
     if (this.labelGold)   this.labelGold.textContent   = '';
     this.refreshMulticlassOptions();
+    if (this.selectAlignment) {
+      const sel = this.selectAlignment as HTMLSelectElement;
+      sel.value = '';
+      sel.disabled = false;
+      for (const opt of Array.from(sel.options)) (opt as HTMLOptionElement).disabled = false;
+    }
+    if (this.profsCard) this.profsCard.style.display = 'none';
+    if (this.spellsCard) this.spellsCard.style.display = 'none';
+    if (this.thiefSkillsCard) this.thiefSkillsCard.style.display = 'none';
+    this.thiefSkillAdds.forEach(input => { if (input) input.value = '0'; });
+    if (this.tsAvail) this.tsAvail.textContent = '0';
+    if (this.tsUsed) this.tsUsed.textContent = '0';
+    if (this.tsRemain) this.tsRemain.textContent = '0';
+    if (this.bardSkillsCard) this.bardSkillsCard.style.display = 'none';
+    this.bardSkillAdds.forEach(input => { if (input) input.value = '0'; });
+    if (this.bsAvail) this.bsAvail.textContent = '0';
+    if (this.bsUsed) this.bsUsed.textContent = '0';
+    if (this.bsRemain) this.bsRemain.textContent = '0';
   };
 
   // re-enable dropdown option
@@ -711,11 +788,11 @@ export class Generator {
   // Roll starting age from race + class tables; for multiclass takes the oldest result
   calcAge = () => {
     const raceKey = this.getCurrentRaceKey();
-    if (!raceKey) { this.age = 0; if (this.labelAge) this.labelAge.textContent = ''; return; }
+    if (!raceKey) { this.baseAge = 0; this.age = 0; if (this.labelAge) this.labelAge.textContent = ''; return; }
     const classes = this.getSelectedClasses();
-    if (!classes.length) { this.age = 0; if (this.labelAge) this.labelAge.textContent = ''; return; }
+    if (!classes.length) { this.baseAge = 0; this.age = 0; if (this.labelAge) this.labelAge.textContent = ''; return; }
     const raceAges = startingAgeTable[raceKey];
-    if (!raceAges) { this.age = 0; if (this.labelAge) this.labelAge.textContent = ''; return; }
+    if (!raceAges) { this.baseAge = 0; this.age = 0; if (this.labelAge) this.labelAge.textContent = ''; return; }
     let maxAge = 0;
     for (const cls of classes) {
       const entry = raceAges[cls];
@@ -723,15 +800,15 @@ export class Generator {
       const rolled = entry.base + rollXdY(entry.dice, entry.sides);
       if (rolled > maxAge) maxAge = rolled;
     }
-    if (!maxAge) { this.age = 0; if (this.labelAge) this.labelAge.textContent = ''; return; }
-    this.age = maxAge;
-    if (this.labelAge) this.labelAge.textContent = this.age.toString();
+    if (!maxAge) { this.baseAge = 0; this.age = 0; if (this.labelAge) this.labelAge.textContent = ''; return; }
+    this.baseAge = maxAge;
+    this.applyLevelToAgeGold();
   };
 
   // Roll starting gold from class tables; for multiclass takes the highest result
   calcMoney = () => {
     const classes = this.getSelectedClasses();
-    if (!classes.length) { this.startingGold = 0; if (this.labelGold) this.labelGold.textContent = ''; return; }
+    if (!classes.length) { this.baseGold = 0; this.startingGold = 0; if (this.labelGold) this.labelGold.textContent = ''; return; }
     let maxGold = 0;
     for (const cls of classes) {
       const entry = startingMoneyTable[cls];
@@ -739,9 +816,19 @@ export class Generator {
       const rolled = rollXdY(entry.dice, entry.sides) * entry.multiplier;
       if (rolled > maxGold) maxGold = rolled;
     }
-    if (!maxGold) { this.startingGold = 0; if (this.labelGold) this.labelGold.textContent = ''; return; }
-    this.startingGold = maxGold;
-    if (this.labelGold) this.labelGold.textContent = `${maxGold} gp`;
+    if (!maxGold) { this.baseGold = 0; this.startingGold = 0; if (this.labelGold) this.labelGold.textContent = ''; return; }
+    this.baseGold = maxGold;
+    this.applyLevelToAgeGold();
+  };
+
+  // Apply level bonus (each level above 1st adds 1 year and 10 gp) to the rolled base values
+  private applyLevelToAgeGold = () => {
+    const level = parseInt((this.selectLevel as HTMLSelectElement)?.value || '0');
+    const bonus = Math.max(0, level - 1);
+    this.age = this.baseAge ? this.baseAge + bonus : 0;
+    this.startingGold = this.baseGold ? this.baseGold + bonus * 10 : 0;
+    if (this.labelAge) this.labelAge.textContent = this.age ? this.age.toString() : '';
+    if (this.labelGold) this.labelGold.textContent = this.startingGold ? `${this.startingGold} gp` : '';
   };
 
   // Set the class (single or multiclass)
@@ -772,6 +859,11 @@ export class Generator {
       this.hitdice = Math.max(...hds);
       this.calcAge();
       this.calcMoney();
+      this.applyAlignmentRestrictions(selected);
+      this.calcProfSlots();
+      this.calcSpellSlots();
+      this.updateThiefSkillsVisibility();
+      this.updateBardSkillsVisibility();
       return;
     }
 
@@ -801,6 +893,11 @@ export class Generator {
     }
     this.calcAge();
     this.calcMoney();
+    this.applyAlignmentRestrictions(this.getSelectedClasses());
+    this.calcProfSlots();
+    this.calcSpellSlots();
+    this.updateThiefSkillsVisibility();
+    this.updateBardSkillsVisibility();
   };
 
   zeroMOds = () => {
@@ -912,6 +1009,8 @@ export class Generator {
   this.refreshMulticlassOptions();
   this.calcPhysical();
   this.calcAge();
+  this.calcThiefSkillBases();
+  this.calcBardSkillBases();
   };
 
   // Calculate hp and thac0
@@ -938,6 +1037,11 @@ export class Generator {
       }
     })();
     this.setLabelValues(meta, ddl.selectedIndex - 1);
+    this.applyLevelToAgeGold();
+    this.calcProfSlots();
+    this.calcSpellSlots();
+    this.updateThiefPoints();
+    this.updateBardPoints();
   };
 
   // Hit dice roll with con mod, minimum roll 1
@@ -1003,8 +1107,201 @@ export class Generator {
       height:      this.height || '',
       weight:      this.weight ? this.weight.toString() : '',
       age:         this.age    ? this.age.toString()    : '',
-      startingGold:this.startingGold ? this.startingGold.toString() : '',
+      startingGold: this.startingGold ? this.startingGold.toString() : '',
+      alignment:    (this.selectAlignment as HTMLSelectElement)?.value || '',
+      wpSlots:      this.labelWpSlots?.textContent || '',
+      nwpSlots:     this.labelNwpSlots?.textContent || '',
     };
+  };
+
+  setAlignment = (_ddl: HTMLSelectElement) => {};
+
+  private applyAlignmentRestrictions = (classes: Classes[]) => {
+    const sel = this.selectAlignment as HTMLSelectElement | null;
+    if (!sel) return;
+    let allowed: string[] | null = null;
+    for (const cls of classes) {
+      const restriction = classAlignmentRestrictions[cls];
+      if (!restriction) continue;
+      allowed = allowed === null ? [...restriction] : allowed.filter(a => restriction.includes(a));
+    }
+    for (const opt of Array.from(sel.options)) {
+      const o = opt as HTMLOptionElement;
+      if (!o.value) continue;
+      o.disabled = allowed !== null && !allowed.includes(o.value);
+    }
+    if (allowed !== null && allowed.length === 1) {
+      sel.value = allowed[0];
+      sel.disabled = true;
+    } else {
+      sel.disabled = false;
+      if (allowed !== null && sel.value && !allowed.includes(sel.value)) sel.value = '';
+    }
+  };
+
+  private calcProfSlots = () => {
+    if (!this.profsCard) return;
+    const classes = this.getSelectedClasses();
+    const level = parseInt((this.selectLevel as HTMLSelectElement).value || '0');
+    if (!classes.length || !level) { this.profsCard.style.display = 'none'; return; }
+    const getGroup = (c: Classes): keyof typeof proficiencySlotData => {
+      if ([Classes.fighter, Classes.paladin, Classes.ranger].includes(c)) return 'warrior';
+      if ([Classes.thief, Classes.bard].includes(c)) return 'rogue';
+      if ([Classes.cleric, Classes.druid].includes(c)) return 'priest';
+      return 'wizard';
+    };
+    let bestWp = 0, bestNwp = 0;
+    for (const cls of classes) {
+      const g = proficiencySlotData[getGroup(cls)];
+      const wp = g.wp.initial + Math.floor((level - 1) / g.wp.per);
+      const nwp = g.nwp.initial + Math.floor((level - 1) / g.nwp.per);
+      if (wp > bestWp) bestWp = wp;
+      if (nwp > bestNwp) bestNwp = nwp;
+    }
+    if (this.labelWpSlots) this.labelWpSlots.textContent = bestWp.toString();
+    if (this.labelNwpSlots) this.labelNwpSlots.textContent = bestNwp.toString();
+    this.profsCard.style.display = '';
+  };
+
+  private calcSpellSlots = () => {
+    if (!this.spellsCard || !this.spellsDl) return;
+    const classes = this.getSelectedClasses();
+    const level = parseInt((this.selectLevel as HTMLSelectElement).value || '0');
+    if (!classes.length || !level) { this.spellsCard.style.display = 'none'; return; }
+    const casters = classes.filter(c => spellSlotsPerDay[c]);
+    if (!casters.length) { this.spellsCard.style.display = 'none'; return; }
+    this.spellsDl.innerHTML = '';
+    const ordinals = ['1st','2nd','3rd','4th','5th','6th','7th','8th','9th'];
+    casters.forEach(cls => {
+      const table = spellSlotsPerDay[cls]!;
+      const slots = table[level - 1];
+      if (!slots) return;
+      const lastNonZero = slots.reduce((m, c, i) => (c > 0 ? i : m), -1);
+      if (lastNonZero < 0) return;
+      if (casters.length > 1) {
+        const dt = document.createElement('dt');
+        dt.textContent = cls.charAt(0).toUpperCase() + cls.slice(1);
+        dt.className = 'spell-class-header';
+        this.spellsDl.appendChild(dt);
+        this.spellsDl.appendChild(document.createElement('dd'));
+      }
+      for (let i = 0; i <= lastNonZero; i++) {
+        const dt = document.createElement('dt');
+        dt.textContent = ordinals[i];
+        const dd = document.createElement('dd');
+        dd.textContent = slots[i] > 0 ? slots[i].toString() : '—';
+        this.spellsDl.appendChild(dt);
+        this.spellsDl.appendChild(dd);
+      }
+    });
+    if (this.spellsDl.children.length === 0) { this.spellsCard.style.display = 'none'; return; }
+    this.spellsCard.style.display = '';
+  };
+
+  private updateThiefSkillsVisibility = () => {
+    if (!this.thiefSkillsCard) return;
+    const isThief = this.getSelectedClasses().includes(Classes.thief);
+    this.thiefSkillsCard.style.display = isThief ? '' : 'none';
+    if (isThief) { this.calcThiefSkillBases(); this.updateThiefPoints(); }
+  };
+
+  private calcThiefSkillBases = () => {
+    if (!this.thiefSkillsCard || this.thiefSkillsCard.style.display === 'none') return;
+    const raceKey = this.getCurrentRaceKey() || 'human';
+    const adj = thiefRaceAdjustments[raceKey] ?? thiefRaceAdjustments['human'];
+    this.thiefSkillBaseValues = [
+      thiefBaseSkills.pp  + adj.pp,
+      thiefBaseSkills.ol  + adj.ol,
+      thiefBaseSkills.frt + adj.frt,
+      thiefBaseSkills.ms  + adj.ms,
+      thiefBaseSkills.his + adj.his,
+      thiefBaseSkills.dn  + adj.dn,
+      thiefBaseSkills.cw  + adj.cw,
+      thiefBaseSkills.rl  + adj.rl,
+    ];
+    this.thiefSkillBaseValues.forEach((val, i) => {
+      if (this.thiefSkillBases[i]) this.thiefSkillBases[i].textContent = `${val}%`;
+    });
+    this.updateThiefTotals();
+  };
+
+  private updateThiefPoints = () => {
+    const level = parseInt((this.selectLevel as HTMLSelectElement).value || '0');
+    const avail = level ? 60 + (level - 1) * 30 : 0;
+    if (this.tsAvail) this.tsAvail.textContent = avail.toString();
+    this.updateThiefTotals();
+  };
+
+  updateThiefSkills = () => { this.updateThiefTotals(); };
+
+  private updateThiefTotals = () => {
+    const level = parseInt((this.selectLevel as HTMLSelectElement).value || '0');
+    const avail = level ? 60 + (level - 1) * 30 : 0;
+    let used = 0;
+    this.thiefSkillAdds.forEach((input, i) => {
+      const added = parseInt(input?.value || '0') || 0;
+      used += added;
+      const total = Math.min((this.thiefSkillBaseValues[i] || 0) + added, 95);
+      if (this.thiefSkillTotals[i]) this.thiefSkillTotals[i].textContent = `${total}%`;
+    });
+    if (this.tsAvail) this.tsAvail.textContent = avail.toString();
+    if (this.tsUsed) this.tsUsed.textContent = used.toString();
+    if (this.tsRemain) {
+      const remaining = avail - used;
+      this.tsRemain.textContent = remaining.toString();
+      this.tsRemain.style.color = remaining < 0 ? 'var(--accent)' : '';
+    }
+  };
+
+  private updateBardSkillsVisibility = () => {
+    if (!this.bardSkillsCard) return;
+    const isBard = this.getSelectedClasses().includes(Classes.bard);
+    this.bardSkillsCard.style.display = isBard ? '' : 'none';
+    if (isBard) { this.calcBardSkillBases(); this.updateBardPoints(); }
+  };
+
+  private calcBardSkillBases = () => {
+    if (!this.bardSkillsCard || this.bardSkillsCard.style.display === 'none') return;
+    const raceKey = this.getCurrentRaceKey() || 'human';
+    const adj = thiefRaceAdjustments[raceKey] ?? thiefRaceAdjustments['human'];
+    this.bardSkillBaseValues = [
+      bardBaseSkills.pp + adj.pp,
+      bardBaseSkills.dn + adj.dn,
+      bardBaseSkills.cw + adj.cw,
+      bardBaseSkills.rl + adj.rl,
+    ];
+    this.bardSkillBaseValues.forEach((val, i) => {
+      if (this.bardSkillBases[i]) this.bardSkillBases[i].textContent = `${val}%`;
+    });
+    this.updateBardTotals();
+  };
+
+  private updateBardPoints = () => {
+    const level = parseInt((this.selectLevel as HTMLSelectElement).value || '0');
+    const avail = level ? level * 20 : 0;
+    if (this.bsAvail) this.bsAvail.textContent = avail.toString();
+    this.updateBardTotals();
+  };
+
+  updateBardSkills = () => { this.updateBardTotals(); };
+
+  private updateBardTotals = () => {
+    const level = parseInt((this.selectLevel as HTMLSelectElement).value || '0');
+    const avail = level ? level * 20 : 0;
+    let used = 0;
+    this.bardSkillAdds.forEach((input, i) => {
+      const added = parseInt(input?.value || '0') || 0;
+      used += added;
+      const total = Math.min((this.bardSkillBaseValues[i] || 0) + added, 95);
+      if (this.bardSkillTotals[i]) this.bardSkillTotals[i].textContent = `${total}%`;
+    });
+    if (this.bsAvail) this.bsAvail.textContent = avail.toString();
+    if (this.bsUsed) this.bsUsed.textContent = used.toString();
+    if (this.bsRemain) {
+      const remaining = avail - used;
+      this.bsRemain.textContent = remaining.toString();
+      this.bsRemain.style.color = remaining < 0 ? 'var(--accent)' : '';
+    }
   };
 
   exportSheet = () => exportCharacterSheet(this.getCharacterData());

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,4 +1,4 @@
-import { Classes, Races, THAC0S, Gender } from './types.js';
+import { Classes, Races, Alignment, THAC0S, Gender } from './types.js';
 import { raceClassLimits, thac0s, savingThrows, heightWeightTable, startingAgeTable, startingMoneyTable, classAlignmentRestrictions, proficiencySlotData, spellSlotsPerDay, thiefBaseSkills, thiefRaceAdjustments, bardBaseSkills } from './data.js';
 import { comboToLabel, getEligibleMulticlassCombos, AbilityScores } from './multiclass.js';
 import { rollDie, roll3d6, roll4d6DropLowest, rollXdY } from './dice.js';
@@ -1011,6 +1011,11 @@ export class Generator {
   this.calcAge();
   this.calcThiefSkillBases();
   this.calcBardSkillBases();
+  this.applyAlignmentRestrictions(this.getSelectedClasses());
+  this.calcProfSlots();
+  this.calcSpellSlots();
+  this.updateThiefSkillsVisibility();
+  this.updateBardSkillsVisibility();
   };
 
   // Calculate hp and thac0
@@ -1119,7 +1124,7 @@ export class Generator {
   private applyAlignmentRestrictions = (classes: Classes[]) => {
     const sel = this.selectAlignment as HTMLSelectElement | null;
     if (!sel) return;
-    let allowed: string[] | null = null;
+    let allowed: Alignment[] | null = null;
     for (const cls of classes) {
       const restriction = classAlignmentRestrictions[cls];
       if (!restriction) continue;
@@ -1128,14 +1133,14 @@ export class Generator {
     for (const opt of Array.from(sel.options)) {
       const o = opt as HTMLOptionElement;
       if (!o.value) continue;
-      o.disabled = allowed !== null && !allowed.includes(o.value);
+      o.disabled = allowed !== null && !allowed.includes(o.value as Alignment);
     }
     if (allowed !== null && allowed.length === 1) {
       sel.value = allowed[0];
       sel.disabled = true;
     } else {
       sel.disabled = false;
-      if (allowed !== null && sel.value && !allowed.includes(sel.value)) sel.value = '';
+      if (allowed !== null && sel.value && !allowed.includes(sel.value as Alignment)) sel.value = '';
     }
   };
 
@@ -1143,7 +1148,12 @@ export class Generator {
     if (!this.profsCard) return;
     const classes = this.getSelectedClasses();
     const level = parseInt((this.selectLevel as HTMLSelectElement).value || '0');
-    if (!classes.length || !level) { this.profsCard.style.display = 'none'; return; }
+    if (!classes.length || !level) {
+      this.profsCard.style.display = 'none';
+      if (this.labelWpSlots) this.labelWpSlots.textContent = '';
+      if (this.labelNwpSlots) this.labelNwpSlots.textContent = '';
+      return;
+    }
     const getGroup = (c: Classes): keyof typeof proficiencySlotData => {
       if ([Classes.fighter, Classes.paladin, Classes.ranger].includes(c)) return 'warrior';
       if ([Classes.thief, Classes.bard].includes(c)) return 'rogue';
@@ -1239,7 +1249,7 @@ export class Generator {
     const avail = level ? 60 + (level - 1) * 30 : 0;
     let used = 0;
     this.thiefSkillAdds.forEach((input, i) => {
-      const added = parseInt(input?.value || '0') || 0;
+      const added = Math.max(0, parseInt(input?.value || '0') || 0);
       used += added;
       const total = Math.min((this.thiefSkillBaseValues[i] || 0) + added, 95);
       if (this.thiefSkillTotals[i]) this.thiefSkillTotals[i].textContent = `${total}%`;
@@ -1290,7 +1300,7 @@ export class Generator {
     const avail = level ? level * 20 : 0;
     let used = 0;
     this.bardSkillAdds.forEach((input, i) => {
-      const added = parseInt(input?.value || '0') || 0;
+      const added = Math.max(0, parseInt(input?.value || '0') || 0);
       used += added;
       const total = Math.min((this.bardSkillBaseValues[i] || 0) + added, 95);
       if (this.bardSkillTotals[i]) this.bardSkillTotals[i].textContent = `${total}%`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,9 +8,12 @@ declare global {
     setClass: (ddl: HTMLSelectElement) => void;
     setLevel: (ddl: HTMLSelectElement) => void;
     setGender: (ddl: HTMLSelectElement) => void;
+    setAlignment: (ddl: HTMLSelectElement) => void;
     noRollType: () => void;
     rollerType: () => void;
     exportSheet: () => void;
+    updateThiefSkills: () => void;
+    updateBardSkills: () => void;
   }
 }
 
@@ -27,7 +30,10 @@ window.addEventListener('load', () => {
   window.setClass = (ddl) => gen.setClass(ddl);
   window.setLevel = (ddl) => gen.setLevel(ddl);
   window.setGender = (ddl) => gen.setGender(ddl);
+  window.setAlignment = (ddl) => gen.setAlignment(ddl);
   window.noRollType = () => gen.dmMode();
   window.rollerType = () => gen.genMode();
   window.exportSheet = () => gen.exportSheet();
+  window.updateThiefSkills = () => gen.updateThiefSkills();
+  window.updateBardSkills = () => gen.updateBardSkills();
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,18 @@ export enum Classes {
   illusionist = 'illusionist'
 }
 
+export enum Alignment {
+  LG = 'LG',
+  LN = 'LN',
+  LE = 'LE',
+  NG = 'NG',
+  TN = 'TN',
+  NE = 'NE',
+  CG = 'CG',
+  CN = 'CN',
+  CE = 'CE',
+}
+
 export enum Races {
   human = 'human',
   dwarf = 'dwarf',

--- a/styles.css
+++ b/styles.css
@@ -496,6 +496,11 @@ body {
     grid-template-columns: repeat(2, 1fr);
     width: 100%;
   }
+  #thief-skills-card,
+  #bard-skills-card {
+    width: 100%;
+    box-sizing: border-box;
+  }
 }
 
 @media (max-width: 520px) {

--- a/styles.css
+++ b/styles.css
@@ -509,3 +509,77 @@ body {
     grid-template-columns: auto 1fr;
   }
 }
+
+/* -- Thief Skills Card ---------------------------------------- */
+.thief-points-info {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  background: var(--parchment-mid);
+  border-bottom: 1px solid var(--parchment-edge);
+}
+
+.thief-points-info strong {
+  color: var(--accent);
+}
+
+.thief-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+}
+
+.thief-table th {
+  background: var(--parchment-mid);
+  color: var(--text-muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.3rem 0.6rem;
+  border-bottom: 1px solid var(--parchment-edge);
+  text-align: left;
+}
+
+.thief-table td {
+  padding: 0.28rem 0.6rem;
+  border-bottom: 1px solid #e8d8b8;
+  vertical-align: middle;
+  color: var(--text);
+}
+
+.thief-table tr:last-child td {
+  border-bottom: none;
+}
+
+.thief-table tr:nth-child(even) td {
+  background: rgba(0,0,0,0.025);
+}
+
+.thief-add {
+  width: 48px;
+  padding: 0.18rem 0.25rem;
+  border: 1px solid var(--parchment-edge);
+  border-radius: 3px;
+  background: #fff9ef;
+  color: var(--text);
+  font-size: 0.82rem;
+  text-align: center;
+  -moz-appearance: textfield;
+}
+
+.thief-add::-webkit-inner-spin-button {
+  display: none;
+}
+
+.spell-class-header {
+  font-weight: 700;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--gold);
+  padding-top: 0.5rem;
+}

--- a/tests/data.test.ts
+++ b/tests/data.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 // Import built JS to avoid TS import extension issues
-import { raceClassLimits, thac0s, savingThrows, heightWeightTable, startingAgeTable, startingMoneyTable } from '../dist/data.js';
+import { raceClassLimits, thac0s, savingThrows, heightWeightTable, startingAgeTable, startingMoneyTable, classAlignmentRestrictions, proficiencySlotData, spellSlotsPerDay, thiefBaseSkills, thiefRaceAdjustments, bardBaseSkills } from '../dist/data.js';
 import { Classes } from '../dist/types.js';
 
 describe('data tables', () => {
@@ -158,5 +158,150 @@ describe('startingMoneyTable', () => {
 
   it('fighters roll more dice than mages', () => {
     expect(startingMoneyTable.fighter.dice).toBeGreaterThan(startingMoneyTable.mage.dice);
+  });
+});
+
+describe('classAlignmentRestrictions', () => {
+  it('paladin is restricted to Lawful Good only', () => {
+    expect(classAlignmentRestrictions[Classes.paladin]).toEqual(['LG']);
+  });
+
+  it('druid is restricted to True Neutral only', () => {
+    expect(classAlignmentRestrictions[Classes.druid]).toEqual(['TN']);
+  });
+
+  it('ranger is restricted to good alignments only', () => {
+    const allowed = classAlignmentRestrictions[Classes.ranger]!;
+    expect(allowed).toContain('LG');
+    expect(allowed).toContain('NG');
+    expect(allowed).toContain('CG');
+    expect(allowed).not.toContain('LE');
+    expect(allowed).not.toContain('CE');
+    expect(allowed).not.toContain('NE');
+  });
+
+  it('fighter has no alignment restriction', () => {
+    expect(classAlignmentRestrictions[Classes.fighter]).toBeUndefined();
+  });
+});
+
+describe('proficiencySlotData', () => {
+  it('warrior has 4 initial weapon profs', () => {
+    expect(proficiencySlotData.warrior.wp.initial).toBe(4);
+  });
+
+  it('wizard has 1 initial weapon prof', () => {
+    expect(proficiencySlotData.wizard.wp.initial).toBe(1);
+  });
+
+  it('all groups have positive initial and per values', () => {
+    for (const group of ['warrior', 'rogue', 'priest', 'wizard'] as const) {
+      const g = proficiencySlotData[group];
+      expect(g.wp.initial).toBeGreaterThan(0);
+      expect(g.nwp.initial).toBeGreaterThan(0);
+      expect(g.wp.per).toBeGreaterThan(0);
+      expect(g.nwp.per).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('spellSlotsPerDay', () => {
+  it('mage has 20 levels of spell slots', () => {
+    expect(spellSlotsPerDay[Classes.mage]).toHaveLength(20);
+  });
+
+  it('mage level 1 has exactly 1 first-level spell and no higher', () => {
+    const slots = spellSlotsPerDay[Classes.mage]![0];
+    expect(slots[0]).toBe(1);
+    expect(slots.slice(1).every((n: number) => n === 0)).toBe(true);
+  });
+
+  it('mage level 20 has 9th-level spells', () => {
+    const slots = spellSlotsPerDay[Classes.mage]![19];
+    expect(slots[8]).toBeGreaterThan(0);
+  });
+
+  it('cleric has 20 levels of spell slots with 7 spell levels', () => {
+    const table = spellSlotsPerDay[Classes.cleric]!;
+    expect(table).toHaveLength(20);
+    expect(table[0]).toHaveLength(7);
+  });
+
+  it('bard level 1 has no spells', () => {
+    const slots = spellSlotsPerDay[Classes.bard]![0];
+    expect(slots.every((n: number) => n === 0)).toBe(true);
+  });
+
+  it('bard level 2 has 1 first-level spell', () => {
+    expect(spellSlotsPerDay[Classes.bard]![1][0]).toBe(1);
+  });
+
+  it('fighter has no spell slot entry', () => {
+    expect(spellSlotsPerDay[Classes.fighter]).toBeUndefined();
+  });
+
+  it('illusionist shares the same table as mage', () => {
+    expect(spellSlotsPerDay[Classes.illusionist]).toBe(spellSlotsPerDay[Classes.mage]);
+  });
+});
+
+describe('thiefBaseSkills', () => {
+  it('has all 8 skill keys', () => {
+    for (const key of ['pp', 'ol', 'frt', 'ms', 'his', 'dn', 'cw', 'rl']) {
+      expect(thiefBaseSkills).toHaveProperty(key);
+    }
+  });
+
+  it('climb walls base is 60', () => {
+    expect(thiefBaseSkills.cw).toBe(60);
+  });
+
+  it('read languages base is 0', () => {
+    expect(thiefBaseSkills.rl).toBe(0);
+  });
+});
+
+describe('thiefRaceAdjustments', () => {
+  const ALL_RACES = ['human', 'dwarf', 'elf', 'gnome', 'halfling', 'halfElf'];
+
+  it('has entries for all six races', () => {
+    for (const race of ALL_RACES) {
+      expect(thiefRaceAdjustments).toHaveProperty(race);
+    }
+  });
+
+  it('human has all zero adjustments', () => {
+    const h = thiefRaceAdjustments['human'];
+    for (const val of Object.values(h)) {
+      expect(val).toBe(0);
+    }
+  });
+
+  it('halfling gets a bonus to move silently and hide in shadows', () => {
+    expect(thiefRaceAdjustments['halfling'].ms).toBeGreaterThan(0);
+    expect(thiefRaceAdjustments['halfling'].his).toBeGreaterThan(0);
+  });
+
+  it('dwarf gets a bonus to open locks and find/remove traps', () => {
+    expect(thiefRaceAdjustments['dwarf'].ol).toBeGreaterThan(0);
+    expect(thiefRaceAdjustments['dwarf'].frt).toBeGreaterThan(0);
+  });
+});
+
+describe('bardBaseSkills', () => {
+  it('has exactly the 4 bard skills', () => {
+    expect(Object.keys(bardBaseSkills)).toEqual(['pp', 'dn', 'cw', 'rl']);
+  });
+
+  it('climb walls base is 60', () => {
+    expect(bardBaseSkills.cw).toBe(60);
+  });
+
+  it('read languages base is 0', () => {
+    expect(bardBaseSkills.rl).toBe(0);
+  });
+
+  it('pick pockets base is 15', () => {
+    expect(bardBaseSkills.pp).toBe(15);
   });
 });

--- a/tests/exporter.test.ts
+++ b/tests/exporter.test.ts
@@ -15,6 +15,7 @@ const baseChar: CharacterData = {
   hp: '24', thac0: '18',
   para: '13', rod: '15', poly: '14', breath: '16', spell: '15',
   height: `5'10"`, weight: '165', age: '19', startingGold: '120',
+  alignment: 'LG', wpSlots: '4', nwpSlots: '3',
 };
 
 // -- cv() --------------------------------------------------------------------
@@ -199,6 +200,21 @@ describe('buildSheetData()', () => {
     // Row 36 = PP, Row 37 = EP, Row 38 = GP (index 37)
     expect(aoa[37][3]).toBe('GP');
     expect(aoa[37][4]).toBe(120); // cv('120') → 120
+  });
+
+  it('row 3 biography data contains alignment', () => {
+    expect(aoa[3][0]).toBe('LG');
+  });
+
+  it('row 26 prof slots are exported when present', () => {
+    expect(aoa[26][5]).toBe('Weapon slots: 4');
+    expect(aoa[26][7]).toBe('NWP slots: 3');
+  });
+
+  it('row 26 prof slot cells are empty when slots absent', () => {
+    const rows = buildSheetData({ ...baseChar, wpSlots: '', nwpSlots: '' });
+    expect(rows[26][5]).toBe('');
+    expect(rows[26][7]).toBe('');
   });
 
   it('handles empty physical/background values gracefully', () => {


### PR DESCRIPTION
Add alignment selection with class-based restrictions, proficiency slot calculation/display, spell-per-day tables, and thief/bard skill UIs with calculations. New data tables for class alignment restrictions, proficiency slot rules, spell slots, thief/bard base skills and racial adjustments were added (src/data.ts). Generator logic and UI wiring were extended to enforce alignment rules, compute prof slots and spell lists, manage thief/bard points and totals, and apply level bonuses to age/gold (src/generator.ts). Exporter now includes alignment and proficiency slots in the exported sheet (src/exporter.ts). index.html and styles.css include the new controls and styling, main.ts exposes new window handlers, and tests were expanded to cover the new data tables (tests/data.test.ts).