### PR TITLE
Enforce class minimums in class selection

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -868,6 +868,16 @@ export class Generator {
       return;
     }
 
+    // No class selected: clear all dependent state
+    if (!selected.length) {
+      this.applyAlignmentRestrictions([]);
+      this.calcProfSlots();
+      this.calcSpellSlots();
+      this.updateThiefSkillsVisibility();
+      this.updateBardSkillsVisibility();
+      return;
+    }
+
     // Fallback to legacy single-class by dropdown index
     switch (ddl.selectedIndex) {
       case 1: // Fighters
@@ -952,7 +962,10 @@ export class Generator {
       if (!opt.value || opt.disabled) continue;
       if (!meetsClassMinimums(abilities, opt.value as Classes)) opt.disabled = true;
     }
-    if (sel.selectedIndex > 0 && sel.options[sel.selectedIndex]?.disabled) sel.selectedIndex = 0;
+    if (sel.selectedIndex > 0 && sel.options[sel.selectedIndex]?.disabled) {
+      sel.selectedIndex = 0;
+      sel.dispatchEvent(new Event('change'));
+    }
   };
 
   private refreshClassDdl = () => {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,6 +1,6 @@
 import { Classes, Races, Alignment, THAC0S, Gender } from './types.js';
 import { raceClassLimits, thac0s, savingThrows, heightWeightTable, startingAgeTable, startingMoneyTable, classAlignmentRestrictions, proficiencySlotData, spellSlotsPerDay, thiefBaseSkills, thiefRaceAdjustments, bardBaseSkills } from './data.js';
-import { comboToLabel, getEligibleMulticlassCombos, AbilityScores } from './multiclass.js';
+import { comboToLabel, getEligibleMulticlassCombos, meetsClassMinimums, AbilityScores } from './multiclass.js';
 import { rollDie, roll3d6, roll4d6DropLowest, rollXdY } from './dice.js';
 import { exportCharacterSheet } from './exporter.js';
 
@@ -484,8 +484,9 @@ export class Generator {
         throw new Error('Impossible stat selected');
     }
     ddl.disabled = true;
-  // Stats changed; recompute multiclass options
+  // Stats changed; recompute multiclass and single-class options
   this.refreshMulticlassOptions();
+  this.refreshClassDdl();
   };
 
   // calculate strength modifiers
@@ -944,6 +945,23 @@ export class Generator {
         break;
       default: throw Error('No idea what species this is?');
     }
+    // Enforce ability score minimums on top of race-based filtering
+    const abilities = this.getAbilities();
+    const sel = this.selectClass as HTMLSelectElement;
+    for (const opt of Array.from(sel.getElementsByTagName('option')) as HTMLOptionElement[]) {
+      if (!opt.value || opt.disabled) continue;
+      if (!meetsClassMinimums(abilities, opt.value as Classes)) opt.disabled = true;
+    }
+    if (sel.selectedIndex > 0 && sel.options[sel.selectedIndex]?.disabled) sel.selectedIndex = 0;
+  };
+
+  private refreshClassDdl = () => {
+    const raceMap: Record<number, Races> = {
+      1: Races.human, 2: Races.dwarf, 3: Races.elf,
+      4: Races.gnome, 5: Races.halfling, 6: Races.halfElf,
+    };
+    const race = raceMap[(this.selectRace as HTMLSelectElement).selectedIndex];
+    if (race) this.enableClassDdl(race);
   };
 
   private dmListeners: (() => void)[] = [];
@@ -953,6 +971,7 @@ export class Generator {
       const val = parseInt(input.value) || 0;
       handler(val);
       this.refreshMulticlassOptions();
+      this.refreshClassDdl();
     };
     input.addEventListener('input', fn);
     this.dmListeners.push(() => input.removeEventListener('input', fn));

--- a/src/multiclass.ts
+++ b/src/multiclass.ts
@@ -12,9 +12,9 @@ export const classMinimums: Record<Classes, Partial<AbilityScores>> = {
   [Classes.paladin]: { str: 12, con: 9, wis: 13, chr: 17 }, // not available to demi-humans
   [Classes.ranger]: { str: 13, dex: 13, con: 14, wis: 14 }, // only elves & half-elves
   [Classes.mage]: { int: 9 },
-  [Classes.illusionist]: { dex: 16, int: 15 },
+  [Classes.illusionist]: { dex: 16, int: 9 },
   [Classes.thief]: { dex: 9 },
-  [Classes.bard]: {}, // not used in combos list provided
+  [Classes.bard]: { dex: 12, int: 13, chr: 15 },
 };
 
 // Allowed multiclass combinations by race from the provided rules

--- a/tests/multiclass.test.ts
+++ b/tests/multiclass.test.ts
@@ -14,7 +14,8 @@ describe('multiclass rules', () => {
   it('class minimums include key classes', () => {
     expect(classMinimums[Classes.fighter]).toBeTruthy();
     expect(classMinimums[Classes.ranger]?.str).toBe(13);
-    expect(classMinimums[Classes.illusionist]?.int).toBe(15);
+    expect(classMinimums[Classes.illusionist]?.dex).toBe(16);
+    expect(classMinimums[Classes.illusionist]?.int).toBe(9);
   });
 
   it('eligible combos are filtered by abilities', () => {
@@ -73,5 +74,44 @@ describe('multiclass rules', () => {
     expect(labels).toContain('cleric+thief');
     expect(labels).toContain('fighter+thief');
     expect(combos).toHaveLength(3);
+  });
+});
+
+describe('class ability minimums', () => {
+  it('paladin requires str 12, con 9, wis 13, chr 17', () => {
+    const good = { str: 12, dex: 0, con: 9, int: 0, wis: 13, chr: 17 };
+    expect(meetsClassMinimums(good, Classes.paladin)).toBe(true);
+    expect(meetsClassMinimums({ ...good, str: 11 }, Classes.paladin)).toBe(false);
+    expect(meetsClassMinimums({ ...good, con: 8 },  Classes.paladin)).toBe(false);
+    expect(meetsClassMinimums({ ...good, wis: 12 }, Classes.paladin)).toBe(false);
+    expect(meetsClassMinimums({ ...good, chr: 16 }, Classes.paladin)).toBe(false);
+  });
+
+  it('ranger requires str 13, dex 13, con 14, wis 14', () => {
+    const good = { str: 13, dex: 13, con: 14, int: 0, wis: 14, chr: 0 };
+    expect(meetsClassMinimums(good, Classes.ranger)).toBe(true);
+    expect(meetsClassMinimums({ ...good, str: 12 }, Classes.ranger)).toBe(false);
+    expect(meetsClassMinimums({ ...good, con: 13 }, Classes.ranger)).toBe(false);
+  });
+
+  it('druid requires wis 12, chr 15', () => {
+    const good = { str: 0, dex: 0, con: 0, int: 0, wis: 12, chr: 15 };
+    expect(meetsClassMinimums(good, Classes.druid)).toBe(true);
+    expect(meetsClassMinimums({ ...good, chr: 14 }, Classes.druid)).toBe(false);
+  });
+
+  it('illusionist requires dex 16, int 9', () => {
+    const good = { str: 0, dex: 16, con: 0, int: 9, wis: 0, chr: 0 };
+    expect(meetsClassMinimums(good, Classes.illusionist)).toBe(true);
+    expect(meetsClassMinimums({ ...good, dex: 15 }, Classes.illusionist)).toBe(false);
+    expect(meetsClassMinimums({ ...good, int: 8 },  Classes.illusionist)).toBe(false);
+  });
+
+  it('bard requires dex 12, int 13, chr 15', () => {
+    const good = { str: 0, dex: 12, con: 0, int: 13, wis: 0, chr: 15 };
+    expect(meetsClassMinimums(good, Classes.bard)).toBe(true);
+    expect(meetsClassMinimums({ ...good, dex: 11 }, Classes.bard)).toBe(false);
+    expect(meetsClassMinimums({ ...good, int: 12 }, Classes.bard)).toBe(false);
+    expect(meetsClassMinimums({ ...good, chr: 14 }, Classes.bard)).toBe(false);
   });
 });


### PR DESCRIPTION
Disable class options that the current ability scores don't meet and refresh class dropdowns when stats change. Import meetsClassMinimums and apply it to single-class <select> options, add refreshClassDdl to reapply race-based class enabling, and call it when abilities are modified. Adjust class minimums: lower illusionist int to 9 and add bard minimums (dex 12, int 13, chr 15). Update tests to reflect the illusionist change and add unit tests for meetsClassMinimums for several classes.